### PR TITLE
Add 'constants' to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "index.js",
-    "device.js"
+    "device.js",
+    "constants.js"
   ],
   "dependencies": {
     "canvas": "^2.6.1",


### PR DESCRIPTION
The `constants.js` file wasn't include by npm in the published module:

```sh
$ C:\Users\adam\dev\loupedeck-live\node_modules\.bin\ts-node .\test.ts
Error: Cannot find module './constants'
Require stack:
- C:\Users\adam\dev\loupedeck-live\node_modules\loupedeck\device.js
- C:\Users\adam\dev\loupedeck-live\node_modules\loupedeck\index.js
```