### PR TITLE
feat: Razer streamcontroller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Loupedeck: Node.js Interface
 
 ![tests](https://github.com/foxxyz/loupedeck/workflows/tests/badge.svg?branch=master)
 
-Unofficial Node.js API for [Loupedeck Live](https://loupedeck.com/products/loupedeck-live/), [Loupedeck Live S](https://loupedeck.com/products/loupedeck-live-s/) & [Loupedeck CT](https://loupedeck.com/us/products/loupedeck-ct/) controllers.
+Unofficial Node.js API for [Loupedeck Live](https://loupedeck.com/products/loupedeck-live/), [Loupedeck Live S](https://loupedeck.com/products/loupedeck-live-s/), [Loupedeck CT](https://loupedeck.com/us/products/loupedeck-ct/) and [Razer Stream](https://www.razer.com/streaming-accessories/razer-stream-controller) controllers.
 
 ![Loupedeck Live Interface](/docs/live-front-small.png?raw=true)
 ![Loupedeck Live S Interface](/docs/live-s-front-small.png?raw=true)
@@ -23,7 +23,7 @@ Requirements
 ------------
 
  * Node 14+
- * Loupedeck Live, Loupedeck Live S or Loupedeck CT
+ * Loupedeck Live, Loupedeck Live S, Loupedeck CT or Razer Stream Controller (RSC)
 
 This library has been tested with firmware versions 0.1.3, 0.1.79, 0.2.5 and 0.2.8. Other versions may work.
 
@@ -92,21 +92,7 @@ For all examples, see the [`examples` folder](/examples/). Running some examples
 
 Find the first connected Loupedeck device and return it.
 
-Returns an instance of `LoupedeckLive`, `LoupedeckLiveS` or `LoupedeckCT`, or throws an `Error` in case none or unsupported devices are found.
-
-### Class `LoupedeckCT`
-
-Implements and supports all methods from the [`LoupedeckDevice` interface](#interface-loupedeckdevice).
-
-#### `new LoupedeckCT({ path : String?, host : String?, autoConnect : Boolean? })`
-
-Create a new Loupedeck CT device interface.
-
-Most use-cases should omit the `host`/`path` parameter, unless you're using multiple devices or know specifically which IP or device path you want to connect to. Either use `path` OR `host`, never both.
-
- - `path`: Serial device path (example: `/dev/cu.ttymodem-1332` or `COM2`) (default: autodiscover)
- - `autoConnect`: Automatically connect during construction. (default: `true`) _Set to `false` if you'd prefer to call [`connect()`](#deviceconnect--promise). yourself._
- - `reconnectInterval`: How many milliseconds to wait before attempting a reconnect after a failed connection (default: `3000`) _Set to `false` to turn off automatic reconnects._
+Returns an instance of `LoupedeckLive`, `LoupedeckLiveS`, `LoupedeckCT`, `RazerStreamController`, or throws an `Error` in case none or unsupported devices are found.
 
 ### Class `LoupedeckLive`
 
@@ -123,17 +109,17 @@ Most use-cases should omit the `host`/`path` parameter, unless you're using mult
  - `autoConnect`: Automatically connect during construction. (default: `true`) _Set to `false` if you'd prefer to call [`connect()`](#deviceconnect--promise). yourself._
  - `reconnectInterval`: How many milliseconds to wait before attempting a reconnect after a failed connection (default: `3000`) _Set to `false` to turn off automatic reconnects._
 
+### Class `LoupedeckCT`
+
+Same interface as [`LoupedeckLive`](#class-loupedecklive).
+
 ### Class `LoupedeckLiveS`
 
-Implements and supports all methods from the [`LoupedeckDevice` interface](#interface-loupedeckdevice).
+Same interface as [`LoupedeckLive`](#class-loupedecklive).
 
-#### `new LoupedeckLiveS({ path : String?, autoConnect : Boolean? })`
+### Class `RazerStreamController`
 
-Create a new Loupedeck Live S interface.
-
- - `path`: Serial device path (example: `/dev/cu.ttymodem-1332` or `COM2`) (default: autodiscover)
- - `autoConnect`: Automatically connect during construction. (default: `true`) _Set to `false` if you'd prefer to call [`connect()`](#deviceconnect--promise). yourself._
- - `reconnectInterval`: How many milliseconds to wait before attempting a reconnect after a failed connection (default: `3000`) _Set to `false` to turn off automatic reconnects._
+Same interface as [`LoupedeckLive`](#class-loupedecklive).
 
 ### Interface `LoupedeckDevice`
 
@@ -222,7 +208,7 @@ Draw graphics to a particular area using a RGB16-565 pixel buffer.
 
 Lower-level method if [`drawKey()`](#devicedrawkeykey--number-buffercallback--bufferfunction--promise) or [`drawScreen()`](#devicedrawscreenscreenid--string-buffercallback--bufferfunction--promise) don't meet your needs.
 
- - `id`: Screen to write to [`left`, `center`, `right`, `knob`] _(`left` and `right` available on Loupedeck Live only)_ _(`knob` available on Loupedeck CT only)_
+ - `id`: Screen to write to [`left`, `center`, `right`, `knob`] _(`left` and `right` available on Loupedeck Live / RSC only)_ _(`knob` available on Loupedeck CT only)_
  - `width`: Width of area to draw
  - `height`: Height of area to draw
  - `x`: Starting X offset (default: `0`)
@@ -238,7 +224,7 @@ Draw graphics to a particular area using the [Canvas API](https://developer.mozi
 
 Lower-level method if [`drawKey()`](#devicedrawkeykey--number-buffercallback--bufferfunction--promise) or [`drawScreen()`](#devicedrawscreenscreenid--string-buffercallback--bufferfunction--promise) don't meet your needs.
 
- - `id`: Screen to write to [`left`, `center`, `right`, `knob`] _(`left` and `right` available on Loupedeck Live only)_ _(`knob` available on Loupedeck CT only)_
+ - `id`: Screen to write to [`left`, `center`, `right`, `knob`] _(`left` and `right` available on Loupedeck Live / RSC only)_ _(`knob` available on Loupedeck CT only)_
  - `width`: Width of area to draw
  - `height`: Height of area to draw
  - `x`: Starting X offset (default: `0`)
@@ -257,7 +243,7 @@ Draw graphics to a specific key.
 
 Second argument can be either a RGB16-565 buffer or a callback. Width and height of callback will be `90`, as keys are 90x90px.
 
- - `key`: Key index to write to ([0-11] on _Loupedeck Live/Loupedeck CT_, [0-14] on _Loupedeck Live S_)
+ - `key`: Key index to write to ([0-11] on _Loupedeck Live/Loupedeck CT/RSC_, [0-14] on _Loupedeck Live S_)
  - `buffer`: RGB16-565 Buffer
  - `callback`: Function to handle draw calls. Receives the following arguments:
      1. `context`: [2d canvas graphics context](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)
@@ -276,7 +262,7 @@ Loupedeck CT:
  * `right`: 60x270px
  * `knob`: 240x240px _(Note: uses big-endian byte order!)_
 
-Loupedeck Live:
+Loupedeck Live / Razer Stream Controller:
  * `left`: 60x270px
  * `center`: 360x270px
  * `right`: 60x270px
@@ -286,7 +272,7 @@ Loupedeck Live S:
  
  Second argument can be either a RGB16-565 buffer or a callback. 
 
- - `screenID`: Screen to write to [`left`, `center`, `right`, `knob`] _(`left` and `right` available on Loupedeck Live only)_ _(`knob` available on Loupedeck CT only)_
+ - `screenID`: Screen to write to [`left`, `center`, `right`, `knob`] _(`left` and `right` available on Loupedeck Live and Razer Stream Controller only)_ _(`knob` available on Loupedeck CT only)_
  - `buffer`: RGB16-565 Buffer (BE for `knob`, LE otherwise)
  - `callback`: Function to handle draw calls. Receives the following arguments:
      1. `context`: [2d canvas graphics context](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)
@@ -316,7 +302,7 @@ Returns a Promise which resolves once the command has been acknowledged by the d
 
 Set a button LED to a particular color.
 
- - `id`: Button ID (possible choices: 0-7 on _Loupedeck Live/CT_, 0-4 on _Loupedeck Live S_, [see `BUTTONS` for _Loupedeck CT_ square buttons](/constants.js#L19))
+ - `id`: Button ID (possible choices: 0-7 on _Loupedeck Live/CT/RSC_, 0-4 on _Loupedeck Live S_, [see `BUTTONS` for _Loupedeck CT_ square buttons](/constants.js#L19))
  - `color`: Any [valid CSS color string](https://github.com/colorjs/color-parse#parsed-strings)
 
 Returns a Promise which resolves once the command has been acknowledged by the device.
@@ -338,7 +324,7 @@ Touch objects are emitted in the [`touchstart`](#event-touchstart), [`touchmove`
  + `y`: Screen Y-coordinate ([0, 270])
  + `target`:
      * `screen`: Identifier of screen this touch was detected on ([`left`, `center`, `right`, `knob`]) (`center` only on _Loupedeck Live S_, `knob` only on _Loupedeck CT_)
-     * `key`: Index of key touched ([0-11] on _Loupedeck Live/CT_, [0-14] on _Loupedeck Live S_)
+     * `key`: Index of key touched ([0-11] on _Loupedeck Live/CT/RSC_, [0-14] on _Loupedeck Live S_)
 
 Contributing & Tests
 --------------------

--- a/connections/serial.js
+++ b/connections/serial.js
@@ -12,6 +12,15 @@ Sec-WebSocket-Key: 123abc
 `
 const WS_UPGRADE_RESPONSE = 'HTTP/1.1'
 
+const VENDOR_IDS = [
+    '2ec2', // Loupedeck
+    '1532', // Razer
+]
+const MANUFACTURERS = [
+    'Loupedeck',
+    'Razer'
+]
+
 class LoupedeckSerialConnection extends EventEmitter {
     constructor({ path } = {}) {
         super()
@@ -22,7 +31,7 @@ class LoupedeckSerialConnection extends EventEmitter {
         const results = []
         for (const info of await SerialPort.list()) {
             const { manufacturer, path, vendorId, productId, serialNumber } = info
-            if (vendorId !== '2ec2' && manufacturer !== 'Loupedeck') continue
+            if (!VENDOR_IDS.includes(vendorId) && !MANUFACTURERS.includes(manufacturer)) continue
             results.push({
                 connectionType: this,
                 path,

--- a/connections/serial.js
+++ b/connections/serial.js
@@ -13,8 +13,8 @@ Sec-WebSocket-Key: 123abc
 const WS_UPGRADE_RESPONSE = 'HTTP/1.1'
 
 const VENDOR_IDS = [
-    '2ec2', // Loupedeck
-    '1532', // Razer
+    0x2ec2, // Loupedeck
+    0x1532, // Razer
 ]
 const MANUFACTURERS = [
     'Loupedeck',
@@ -30,7 +30,9 @@ class LoupedeckSerialConnection extends EventEmitter {
     static async discover() {
         const results = []
         for (const info of await SerialPort.list()) {
-            const { manufacturer, path, vendorId, productId, serialNumber } = info
+            const { manufacturer, path, serialNumber } = info
+            const vendorId = parseInt(info.vendorId, 16)
+            const productId = parseInt(info.productId, 16)
             if (!VENDOR_IDS.includes(vendorId) && !MANUFACTURERS.includes(manufacturer)) continue
             results.push({
                 connectionType: this,

--- a/connections/web-serial.js
+++ b/connections/web-serial.js
@@ -65,7 +65,7 @@ class LoupedeckWebSerialConnection extends EventEmitter {
         if (!ports.length) {
             // Request a new port
             try {
-                ports.push(await navigator.serial.requestPort({ filters: [{ usbVendorId: 0x2ec2 }] }))
+                ports.push(await navigator.serial.requestPort({ filters: [{ usbVendorId: 0x2ec2 }, { usbVendorId: 0x1532 }] }))
             } catch (e) {
                 console.warn('Unable to open port!')
             }

--- a/device.js
+++ b/device.js
@@ -265,8 +265,8 @@ class LoupedeckDevice extends EventEmitter {
 }
 
 class LoupedeckLive extends LoupedeckDevice {
-    static productId = '0004'
-    static vendorId = '2ec2'
+    static productId = 0x0004
+    static vendorId = 0x2ec2
     buttons = [0, 1, 2, 3, 4, 5, 6, 7]
     knobs = ['knobCL', 'knobCR', 'knobTL', 'knobTR', 'knobBL', 'knobBR']
     columns = 4
@@ -293,7 +293,7 @@ class LoupedeckLive extends LoupedeckDevice {
 }
 
 class LoupedeckCT extends LoupedeckLive {
-    static productId = '0003'
+    static productId = 0x0003
     buttons = [0, 1, 2, 3, 4, 5, 6, 7, 'home', 'enter', 'undo', 'save', 'keyboard', 'fnL', 'a', 'b', 'c', 'd', 'fnR', 'e']
     displays = {
         center: { id: Buffer.from('\x00A'), width: 360, height: 270 }, // "A"
@@ -310,8 +310,8 @@ class LoupedeckCT extends LoupedeckLive {
 }
 
 class LoupedeckLiveS extends LoupedeckDevice {
-    static productId = '0006'
-    static vendorId = '2ec2'
+    static productId = 0x0006
+    static vendorId = 0x2ec2
     buttons = [0, 1, 2, 3]
     knobs = ['knobCL', 'knobTL']
     columns = 5
@@ -335,8 +335,9 @@ class LoupedeckLiveS extends LoupedeckDevice {
 }
 
 class RazerStreamController extends LoupedeckLive {
-    static productId = '0d06'
-    static vendorId = '1532'
+    static productId = 0x0d06
+    static vendorId = 0x1532
+    type = 'Razer Stream Controller'
     // All displays are addressed as the same screen
     // So we add offsets
     displays = {

--- a/device.js
+++ b/device.js
@@ -93,6 +93,10 @@ class LoupedeckDevice extends EventEmitter {
         if (!displayInfo) throw new Error(`Display '${id}' is not available on this device!`)
         if (!width) width = displayInfo.width
         if (!height) height = displayInfo.height
+        if (displayInfo.offset) {
+            x += displayInfo.offset[0]
+            y += displayInfo.offset[1]
+        }
 
         const pixelCount = width * height * 2
         if (buffer.length !== pixelCount) {
@@ -333,6 +337,13 @@ class LoupedeckLiveS extends LoupedeckDevice {
 class RazerStreamController extends LoupedeckLive {
     static productId = '0d06'
     static vendorId = '1532'
+    // All displays are addressed as the same screen
+    // So we add offsets
+    displays = {
+        center: { id: Buffer.from('\x00M'), width: 360, height: 270, offset: [60, 0] },
+        left: { id: Buffer.from('\x00M'), width: 60, height: 270 },
+        right: { id: Buffer.from('\x00M'), width: 60, height: 270, offset: [420, 0] },
+    }
 }
 
 module.exports = {

--- a/device.js
+++ b/device.js
@@ -261,6 +261,8 @@ class LoupedeckDevice extends EventEmitter {
 }
 
 class LoupedeckLive extends LoupedeckDevice {
+    static productId = '0004'
+    static vendorId = '2ec2'
     buttons = [0, 1, 2, 3, 4, 5, 6, 7]
     knobs = ['knobCL', 'knobCR', 'knobTL', 'knobTR', 'knobBL', 'knobBR']
     columns = 4
@@ -269,7 +271,6 @@ class LoupedeckLive extends LoupedeckDevice {
         left: { id: Buffer.from('\x00L'), width: 60, height: 270 }, // "L"
         right: { id: Buffer.from('\x00R'), width: 60, height: 270 }, // "R"
     }
-    productId = '0004'
     rows = 3
     type = 'Loupedeck Live'
     visibleX = [0, 480]
@@ -288,6 +289,7 @@ class LoupedeckLive extends LoupedeckDevice {
 }
 
 class LoupedeckCT extends LoupedeckLive {
+    static productId = '0003'
     buttons = [0, 1, 2, 3, 4, 5, 6, 7, 'home', 'enter', 'undo', 'save', 'keyboard', 'fnL', 'a', 'b', 'c', 'd', 'fnR', 'e']
     displays = {
         center: { id: Buffer.from('\x00A'), width: 360, height: 270 }, // "A"
@@ -295,7 +297,6 @@ class LoupedeckCT extends LoupedeckLive {
         right: { id: Buffer.from('\x00R'), width: 60, height: 270 }, // "R"
         knob: { id: Buffer.from('\x00W'), width: 240, height: 240, endianness: 'be' }, // "W"
     }
-    productId = '0003'
     type = 'Loupedeck CT'
     // Determine touch target based on x/y position
     getTarget(x, y, id) {
@@ -305,13 +306,14 @@ class LoupedeckCT extends LoupedeckLive {
 }
 
 class LoupedeckLiveS extends LoupedeckDevice {
+    static productId = '0006'
+    static vendorId = '2ec2'
     buttons = [0, 1, 2, 3]
     knobs = ['knobCL', 'knobTL']
     columns = 5
     displays = {
         center: { id: Buffer.from('\x00M'), width: 480, height: 270 },
     }
-    productId = '0006'
     rows = 3
     type = 'Loupedeck Live S'
     visibleX = [15, 465]
@@ -328,9 +330,15 @@ class LoupedeckLiveS extends LoupedeckDevice {
     }
 }
 
+class RazerStreamController extends LoupedeckLive {
+    static productId = '0d06'
+    static vendorId = '1532'
+}
+
 module.exports = {
     LoupedeckCT,
     LoupedeckDevice,
     LoupedeckLive,
     LoupedeckLiveS,
+    RazerStreamController,
 }

--- a/discovery.js
+++ b/discovery.js
@@ -1,16 +1,10 @@
-const { LoupedeckCT, LoupedeckDevice, LoupedeckLive, LoupedeckLiveS } = require('./device')
-
-const USB_PRODUCT_IDS = {
-    3: LoupedeckCT,
-    4: LoupedeckLive,
-    6: LoupedeckLiveS,
-}
+const ALL_DEVICES = require('./device')
 
 async function discover() {
-    const devices = await LoupedeckDevice.list()
+    const devices = await ALL_DEVICES.LoupedeckDevice.list()
     if (devices.length === 0) throw new Error('No devices found')
     const { productId, ...args } = devices[0]
-    const deviceType = USB_PRODUCT_IDS[parseInt(productId)]
+    const deviceType = Object.values(ALL_DEVICES).find(dev => dev.productId === productId)
     if (!deviceType) throw new Error(`Device with product ID ${productId} not yet supported! Please file an issue at https://github.com/foxxyz/loupedeck/issues`)
     const device = new deviceType(args)
     return device

--- a/examples/simple/index.mjs
+++ b/examples/simple/index.mjs
@@ -58,6 +58,7 @@ loupedeck.on('rotate', ({ id, delta }) => {
 
 loupedeck.on('touchstart', ({ changedTouches: [touch] }) => {
     console.log(`Touch #${touch.id} started: x: ${touch.x}, y: ${touch.y}`)
+    console.log(touch.target)
     // Clear key when touched
     if (touch.target.key !== undefined) {
         loupedeck.drawKey(touch.target.key, (ctx, w, h) => {

--- a/examples/web/src/app.vue
+++ b/examples/web/src/app.vue
@@ -66,7 +66,7 @@ import { nextTick, reactive, ref, watch } from 'vue'
 import { Buffer } from 'buffer'
 window.Buffer = Buffer
 
-import { discover, LoupedeckLive, LoupedeckLiveS, LoupedeckCT } from 'loupedeck'
+import { discover, LoupedeckLive, LoupedeckLiveS, LoupedeckCT, RazerStreamController } from 'loupedeck'
 
 import loupedeckButton from './components/loupedeck-button.vue'
 import loupedeckButtonSquare from './components/loupedeck-button-square.vue'
@@ -77,6 +77,7 @@ const DEVICE_TYPES = [
     LoupedeckCT,
     LoupedeckLive,
     LoupedeckLiveS,
+    RazerStreamController,
 ]
 
 const connected = ref(false)
@@ -236,7 +237,7 @@ body
             height: 100%
             width: 100%
 
-.LoupedeckLive, .LoupedeckCT
+.LoupedeckLive, .LoupedeckCT, .RazerStreamController
     @container (min-width: 0px)
         .screen
             border-radius: 2cqw

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-const { LoupedeckCT, LoupedeckLive, LoupedeckLiveS } = require('./device')
+const DEVICES = require('./device')
 const { HAPTIC } = require('./constants')
 const { discover } = require('./discovery')
 
 module.exports = {
     discover,
-    LoupedeckCT,
-    LoupedeckLive,
-    LoupedeckLiveS,
-    HAPTIC
+    HAPTIC,
+    ...DEVICES,
 }

--- a/test/connection-serial.test.js
+++ b/test/connection-serial.test.js
@@ -5,7 +5,7 @@ let connection
 
 describe('v0.2.X Connection', () => {
     it('auto-discovers valid connections', async() => {
-        expect(await SerialConnection.discover()).toEqual([{ connectionType: SerialConnection, path: '/dev/cu.usbmodem-333', productId: '0004', serialNumber: 'LDD12345678', vendorId: '2ec2' }])
+        expect(await SerialConnection.discover()).toEqual([{ connectionType: SerialConnection, path: '/dev/cu.usbmodem-333', productId: 0x0004, serialNumber: 'LDD12345678', vendorId: 0x2ec2 }])
     })
     it('connects via direct instantiation', async() => {
         connection = new SerialConnection({ path: '/dev/fake-path' })

--- a/test/device-razer.test.js
+++ b/test/device-razer.test.js
@@ -1,0 +1,217 @@
+const { RazerStreamController } = require('..')
+
+expect.extend({
+    toBePixelBuffer(received, { displayID, x, y, width, height }) {
+        if (received.readUInt16BE(0) !== 0xff10) return { pass: false, message: () => `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}` }
+        if (received.readUInt16BE(3) !== displayID) return { pass: false, message: () => `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}` }
+        if (received.readUInt16BE(5) !== x) return { pass: false, message: () => `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}` }
+        if (received.readUInt16BE(7) !== y) return { pass: false, message: () => `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}` }
+        if (received.readUInt16BE(9) !== width) return { pass: false, message: () => `Width should be ${width}, but found ${received.readUInt16BE(9)}` }
+        if (received.readUInt16BE(11) !== height) return { pass: false, message: () => `Height should be ${height}, but found ${received.readUInt16BE(11)}` }
+        const correctLength = 13 + width * height * 2
+        if (received.length !== correctLength) return { pass: false, message: () => `Buffer length should be ${correctLength}, but found ${received.length}` }
+        return { pass: true }
+    }
+})
+
+const delay = ms => new Promise(res => setTimeout(res, ms))
+
+let device
+
+describe('Commands', () => {
+    beforeEach(() => {
+        device = new RazerStreamController({ autoConnect: false })
+        device.connection = { send: () => {}, isReady: () => true }
+    })
+    it('retrieves device information', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        const promise = device.getInfo()
+        expect(sender).toHaveBeenCalledWith(Buffer.from('030301', 'hex'))
+        device.onReceive(Buffer.from('1f0301525a32313031303133303030333936373030313338413030303120', 'hex'))
+        await delay(20)
+        expect(sender).toHaveBeenCalledWith(Buffer.from('030702', 'hex'))
+        device.onReceive(Buffer.from('0c0702000208050000000000', 'hex'))
+        expect(promise).resolves.toEqual({
+            version: '0.2.8',
+            serial: 'RZ2101013000396700138A0001'
+        })
+    })
+    it('rejects retrieving device information if not connected', async() => {
+        device.connection = { send: () => {}, isReady: () => false }
+        const promise = device.getInfo()
+        await expect(promise).rejects.toThrow(/not connected/i)
+    })
+    it('sets brightness', () => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.setBrightness(0)
+        expect(sender).toHaveBeenCalledWith(Buffer.from('04090100', 'hex'))
+        device.setBrightness(1)
+        // 0x0b should be max brightness
+        expect(sender).toHaveBeenCalledWith(Buffer.from('0409020a', 'hex'))
+    })
+    it('sets button color', () => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.setButtonColor({ id: 4, color: 'red' })
+        expect(sender).toHaveBeenCalledWith(Buffer.from('0702010bff0000', 'hex'))
+    })
+    it('errors on unknown button passed', () => {
+        expect(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
+    })
+    it('vibrates short by default', () => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.vibrate()
+        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0101', 'hex'))
+    })
+    it('vibrates a specific pattern', () => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.vibrate(0x56)
+        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0156', 'hex'))
+    })
+})
+describe('Drawing (Callback API)', () => {
+    beforeEach(() => {
+        device = new RazerStreamController({ autoConnect: false })
+        device.connection = { send: () => {}, isReady: () => true }
+    })
+    it('writes pixels to left display', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.drawScreen('left', (ctx, w, h) => {
+            ctx.fillStyle = '#f00' // red
+            ctx.fillRect(0, 0, w, h)
+        })
+        // Color format is 5-6-5 16-bit RGB
+        // so first 5 bits for full red is 0xf800, or 0x00f8 in LE
+        const pixels = '00f8'.repeat(60 * 270)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels to right display', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.drawScreen('right', (ctx, w, h) => {
+            ctx.fillStyle = '#0f0' // green
+            ctx.fillRect(0, 0, w, h)
+        })
+        // Color format is 5-6-5 16-bit RGB
+        // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
+        const pixels = 'e007'.repeat(60 * 270)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels to center display', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.drawScreen('center', (ctx, w, h) => {
+            ctx.fillStyle = '#00f' // blue
+            ctx.fillRect(0, 0, w, h)
+        })
+        // Color format is 5-6-5 16-bit RGB
+        // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
+        const pixels = '1f00'.repeat(360 * 270)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels to a specific key area', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.drawKey(6, (ctx, w, h) => {
+            ctx.fillStyle = '#fff'
+            ctx.fillRect(0, 0, w, h)
+        })
+        const pixels = 'ffff'.repeat(90 * 90)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels without refreshing the screen', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        device.drawCanvas({ id: 'center', width: 10, height: 10, autoRefresh: false }, () => {})
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenCalledTimes(1)
+    })
+    it('informs the user if the canvas library is not installed', () => {
+        jest.mock('canvas', () => {})
+        expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+    })
+})
+describe('Drawing (Buffer API)', () => {
+    beforeEach(() => {
+        device = new RazerStreamController({ autoConnect: false })
+        device.connection = { send: () => {}, isReady: () => true }
+    })
+    it('writes pixels to left display', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        const pixels = Array(60 * 270).fill([0x00, 0xf8])
+        const buffer = Buffer.from(pixels.flat())
+        device.drawScreen('left', buffer)
+        const hex = '00f8'.repeat(60 * 270)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels to right display', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        const pixels = Array(60 * 270).fill([0xe0, 0x07])
+        const buffer = Buffer.from(pixels.flat())
+        device.drawScreen('right', buffer)
+        // Color format is 5-6-5 16-bit RGB
+        // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
+        const hex = 'e007'.repeat(60 * 270)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels to center display', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        const pixels = Array(360 * 270).fill([0x1f, 0x00])
+        const buffer = Buffer.from(pixels.flat())
+        device.drawScreen('center', buffer)
+        // Color format is 5-6-5 16-bit RGB
+        // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
+        const hex = '1f00'.repeat(360 * 270)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('writes pixels to a specific key area', async() => {
+        const sender = jest.spyOn(device.connection, 'send')
+        const pixels = Array(90 * 90 * 2).fill(0xff)
+        const buffer = Buffer.from(pixels)
+        device.drawKey(6, buffer)
+        const hex = 'ffff'.repeat(90 * 90)
+        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        // Confirm write
+        device.onReceive(Buffer.from('041001', 'hex'))
+        await delay(10)
+        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+    })
+    it('reports an error if the buffer is the wrong size', async() => {
+        const pixels = Array(30).fill(0xff)
+        const buffer = Buffer.from(pixels)
+        await expect(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
+    })
+})


### PR DESCRIPTION
Implements support for Razer Stream Controller devices

 - refactor(examples): The simple, slide puzzle, and web serial examples now work with Razer Stream Controller devices
 - refactor: USB Product and vendor ID are now handled in hex instead of strings
 - docs: Update docs for Razer Stream Controller compatibility

closes #25 