### PR TITLE
Migrate to ESM, Replace Jest with native test runner

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x, latest]
+        node-version: [20.x, 22.x, 23.x, latest]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Update repositories 
+      run: sudo apt-get update
     - name: Install system dependencies
       run: sudo apt-get install libcairo2-dev libpango1.0-dev libgif-dev
     - run: npm ci

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Supports:
 Requirements
 ------------
 
- * Node 18+
- * Supported Device
+ * Node 20+
+ * Supported Devices:
    * Loupedeck Live
    * Loupedeck Live S
    * Loupedeck CT

--- a/__mocks__/serialport.js
+++ b/__mocks__/serialport.js
@@ -15,7 +15,7 @@ Sec-WebSocket-Accept: PLOTDYCXHOTMeouth==
 `
 
 // Stand-in for a Loupedeck serial device
-export class SerialPort extends EventEmitter {
+export class MockSerialPort extends EventEmitter {
     static list() {
         return [
             {

--- a/__mocks__/ws.js
+++ b/__mocks__/ws.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events'
 
 // Stand-in for a real WebSocket
-export default class MockSocket extends EventEmitter {
+export class MockSocket extends EventEmitter {
     constructor(url) {
         super()
         this.url = url

--- a/device.js
+++ b/device.js
@@ -10,6 +10,14 @@ if (typeof navigator !== 'undefined' && navigator.serial || import.meta.env?.PRO
     WSConnection = (await import('./connections/ws.js')).default
 }
 
+let canvasModule
+try {
+    canvasModule = await import('canvas')
+// eslint-disable-next-line
+} catch (e) {
+    // No canvas is ok, do check in `drawCanvas`
+}
+
 import {
     BUTTONS,
     COMMANDS,

--- a/device.js
+++ b/device.js
@@ -10,14 +10,6 @@ if (typeof navigator !== 'undefined' && navigator.serial || import.meta.env?.PRO
     WSConnection = (await import('./connections/ws.js')).default
 }
 
-let canvasModule
-try {
-    canvasModule = await import('canvas')
-// eslint-disable-next-line
-} catch (e) {
-    // No canvas is ok, do check in `drawCanvas`
-}
-
 import {
     BUTTONS,
     COMMANDS,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,8 @@
 import jsConfig from '@appliedminds/eslint-config'
-import jest from 'eslint-plugin-jest'
 import globals from 'globals'
 
 export default [
     ...jsConfig,
-    jest.configs['flat/recommended'],
     {
         languageOptions: {
             globals: {

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -8,8 +8,8 @@ It uses [Vite](https://github.com/vitejs/vite) & [Vue 3](https://github.com/vuej
 Requirements
 ------------
 
- * Node 16+
- * Supported Browser
+ * Node 20+
+ * Supported Browsers
    * Google Chrome 89+
    * Microsoft Edge 89+
    * Opera 67+

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -1,48 +1,47 @@
 {
   "name": "loupedeck-web-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loupedeck-web-example",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "events": "^3.3.0",
         "loupedeck": "file:../..",
-        "vue": "^3.4.27"
+        "vue": "^3.5.13"
       },
       "devDependencies": {
-        "@appliedminds/eslint-config": "^2.0.1",
-        "@vitejs/plugin-vue": "^5.0.4",
-        "eslint": "^9.3.0",
-        "eslint-plugin-vue": "^9.26.0",
-        "sass": "^1.77.2",
-        "vite": "^5.2.11"
+        "@appliedminds/eslint-config": "^2.0.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "eslint": "^9.19.0",
+        "eslint-plugin-vue": "^9.32.0",
+        "sass": "^1.83.4",
+        "vite": "^6.0.11"
       }
     },
     "../..": {
-      "version": "5.1.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "color-rgba": "^3.0.0",
         "events": "^3.3.0",
-        "serialport": "^12.0.0",
-        "ws": "^8.17.0"
+        "serialport": "^13.0.0",
+        "strict-event-emitter": "^0.5.1",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
-        "@appliedminds/eslint-config": "^2.0.1",
-        "eslint": "^9.3.0",
-        "eslint-plugin-jest": "^28.5.0",
-        "jest": "^29.7.0"
+        "@appliedminds/eslint-config": "^2.0.2",
+        "eslint": "^9.19.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0-rc3"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -60,22 +59,46 @@
       }
     },
     "node_modules/@appliedminds/eslint-config": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@appliedminds/eslint-config/-/eslint-config-2.0.1.tgz",
-      "integrity": "sha512-bViUcyzuOw3nvd33nuP9P63oXMlQYFdWRUvYgTg+mFunE+15ezjFDSIwkB05VtWnwBSmXzeZiCN1BFrElFGGEw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@appliedminds/eslint-config/-/eslint-config-2.0.2.tgz",
+      "integrity": "sha512-sv+W113zOc3UKumP03mXBcZR2/rhUYazy6tqZioTdrEWWWO0Uf/qb3sP+TsOgGxHjdctV4LaH736g0TPWQO0YQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.0.0"
+        "@eslint/js": "^9.13.0",
+        "globals": "^15.11.0"
       },
       "peerDependencies": {
         "eslint": ">=9.0.0",
         "eslint-plugin-vue": ">=9.0.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.6.tgz",
-      "integrity": "sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.7"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -83,372 +106,442 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/types": {
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -467,19 +560,49 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+    "node_modules/@eslint/config-array": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -498,27 +621,89 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.3.0.tgz",
-      "integrity": "sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==",
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
+      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "@eslint/core": "^0.10.0",
+        "levn": "^0.4.1"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -534,17 +719,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "dev": true
-    },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -554,367 +734,721 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
+        "node": ">= 10.0.0"
       },
-      "engines": {
-        "node": ">= 8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.0.tgz",
+      "integrity": "sha512-Eeao7ewDq79jVEsrtWIj5RNqB8p2knlm9fhR6uJ2gqP7UfbLrTrxevudVrEPDM7Wkpn/HpRC2QfazH7MXLz3vQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.0.tgz",
+      "integrity": "sha512-yVh0Kf1f0Fq4tWNf6mWcbQBCLDpDrDEl88lzPgKhrgTcDrTtlmun92ywEF9dCjmYO3EFiSuJeeo9cYRxl2FswA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.0.tgz",
+      "integrity": "sha512-gCs0ErAZ9s0Osejpc3qahTsqIPUDjSKIyxK/0BGKvL+Tn0n3Kwvj8BrCv7Y5sR1Ypz1K2qz9Ny0VvkVyoXBVUQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.0.tgz",
+      "integrity": "sha512-aIB5Anc8hngk15t3GUkiO4pv42ykXHfmpXGS+CzM9CTyiWyT8HIS5ygRAy7KcFb/wiw4Br+vh1byqcHRTfq2tQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.0.tgz",
+      "integrity": "sha512-kpdsUdMlVJMRMaOf/tIvxk8TQdzHhY47imwmASOuMajg/GXpw8GKNd8LNwIHE5Yd1onehNpcUB9jHY6wgw9nHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.0.tgz",
+      "integrity": "sha512-D0RDyHygOBCQiqookcPevrvgEarN0CttBecG4chOeIYCNtlKHmf5oi5kAVpXV7qs0Xh/WO2RnxeicZPtT50V0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.0.tgz",
+      "integrity": "sha512-mCIw8j5LPDXmCOW8mfMZwT6F/Kza03EnSr4wGYEswrEfjTfVsFOxvgYfuRMxTuUF/XmRb9WSMD5GhCWDe2iNrg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.0.tgz",
+      "integrity": "sha512-AwwldAu4aCJPob7zmjuDUMvvuatgs8B/QiVB0KwkUarAcPB3W+ToOT+18TQwY4z09Al7G0BvCcmLRop5zBLTag==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.0.tgz",
+      "integrity": "sha512-e7kDUGVP+xw05pV65ZKb0zulRploU3gTu6qH1qL58PrULDGxULIS0OSDQJLH7WiFnpd3ZKUU4VM3u/Z7Zw+e7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.0.tgz",
+      "integrity": "sha512-SXYJw3zpwHgaBqTXeAZ31qfW/v50wq4HhNVvKFhRr5MnptRX2Af4KebLWR1wpxGJtLgfS2hEPuALRIY3LPAAcA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.0.tgz",
+      "integrity": "sha512-e5XiCinINCI4RdyU3sFyBH4zzz7LiQRvHqDtRe9Dt8o/8hTBaYpdPimayF00eY2qy5j4PaaWK0azRgUench6WQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.0.tgz",
+      "integrity": "sha512-3SWN3e0bAsm9ToprLFBSro8nJe6YN+5xmB11N4FfNf92wvLye/+Rh5JGQtKOpwLKt6e61R1RBc9g+luLJsc23A==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.0.tgz",
+      "integrity": "sha512-B1Oqt3GLh7qmhvfnc2WQla4NuHlcxAD5LyueUi5WtMc76ZWY+6qDtQYqnxARx9r+7mDGfamD+8kTJO0pKUJeJA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.0.tgz",
+      "integrity": "sha512-UfUCo0h/uj48Jq2lnhX0AOhZPSTAq3Eostas+XZ+GGk22pI+Op1Y6cxQ1JkUuKYu2iU+mXj1QjPrZm9nNWV9rg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.0.tgz",
+      "integrity": "sha512-chZLTUIPbgcpm+Z7ALmomXW8Zh+wE2icrG+K6nt/HenPLmtwCajhQC5flNSk1Xy5EDMt/QAOz2MhzfOfJOLSiA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.0.tgz",
+      "integrity": "sha512-jo0UolK70O28BifvEsFD/8r25shFezl0aUk2t0VJzREWHkq19e+pcLu4kX5HiVXNz5qqkD+aAq04Ct8rkxgbyQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.0.tgz",
+      "integrity": "sha512-Vmg0NhAap2S54JojJchiu5An54qa6t/oKT7LmDaWggpIcaiL8WcWHEN6OQrfTdL6mQ2GFyH7j2T5/3YPEDOOGA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.0.tgz",
+      "integrity": "sha512-CV2aqhDDOsABKHKhNcs1SZFryffQf8vK2XrxP6lxC99ELZAdvsDgPklIBfd65R8R+qvOm1SmLaZ/Fdq961+m7A==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.0.tgz",
+      "integrity": "sha512-g2ASy1QwHP88y5KWvblUolJz9rN+i4ZOsYzkEwcNfaNooxNUXG+ON6F5xFo0NIItpHqxcdAyls05VXpBnludGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz",
-      "integrity": "sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.1.tgz",
+      "integrity": "sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.24.4",
-        "@vue/shared": "3.4.27",
+        "@babel/parser": "^7.25.3",
+        "@vue/shared": "3.5.13",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.4.27",
-        "@vue/shared": "3.4.27"
+        "@vue/compiler-core": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
-      "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.24.4",
-        "@vue/compiler-core": "3.4.27",
-        "@vue/compiler-dom": "3.4.27",
-        "@vue/compiler-ssr": "3.4.27",
-        "@vue/shared": "3.4.27",
+        "@babel/parser": "^7.25.3",
+        "@vue/compiler-core": "3.5.13",
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.10",
-        "postcss": "^8.4.38",
+        "magic-string": "^0.30.11",
+        "postcss": "^8.4.48",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
-      "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.27",
-        "@vue/shared": "3.4.27"
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
-      "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.4.27"
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
-      "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.4.27",
-        "@vue/shared": "3.4.27"
+        "@vue/reactivity": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
-      "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/runtime-core": "3.4.27",
-        "@vue/shared": "3.4.27",
+        "@vue/reactivity": "3.5.13",
+        "@vue/runtime-core": "3.5.13",
+        "@vue/shared": "3.5.13",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
-      "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.27",
-        "@vue/shared": "3.4.27"
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13"
       },
       "peerDependencies": {
-        "vue": "3.4.27"
+        "vue": "3.5.13"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -927,6 +1461,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -936,6 +1471,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -945,15 +1481,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -971,30 +1498,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1015,15 +1531,6 @@
         }
       ]
     },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1035,18 +1542,21 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1080,6 +1590,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1101,42 +1612,19 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/color-convert": {
@@ -1161,13 +1649,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1192,7 +1682,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1217,10 +1708,25 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -1229,41 +1735,44 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1279,28 +1788,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.3.0.tgz",
-      "integrity": "sha512-5Iv4CsZW030lpUqHBapdPo3MJetAPtejVW8B84GIcIIv8+ohFaddXsrn1Gn8uD9ijDb+kcYKFUVmC8qG8B2ORQ==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
+      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.3.0",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.10.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.19.0",
+        "@eslint/plugin-kit": "^0.2.5",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.0",
-        "@nodelib/fs.walk": "^1.2.8",
+        "@humanwhocodes/retry": "^0.4.1",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.0.1",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.0.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1309,15 +1823,11 @@
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -1326,22 +1836,31 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.26.0.tgz",
-      "integrity": "sha512-eTvlxXgd4ijE1cdur850G6KalZqk65k1JKoOI2d1kT3hr8sPD07j1q98FRFdNnpxBELGPWxZmInxeHGF/GxtqQ==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.32.0.tgz",
+      "integrity": "sha512-b/Y05HYmnB/32wqVcjxjHZzNpwxj1onBOvqW89W+V+XNG1dRuaFbNd3vT9CLbr2LXjEoq+3vn8DanWf7XU22Ug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "globals": "^13.24.0",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
         "postcss-selector-parser": "^6.0.15",
-        "semver": "^7.6.0",
-        "vue-eslint-parser": "^9.4.2",
+        "semver": "^7.6.3",
+        "vue-eslint-parser": "^9.4.3",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -1367,10 +1886,11 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.1.tgz",
-      "integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -1395,10 +1915,11 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1407,14 +1928,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.11.3",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.0.0"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1424,10 +1946,11 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1436,10 +1959,11 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -1452,6 +1976,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1464,6 +1989,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -1471,7 +1997,8 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -1494,28 +2021,21 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -1530,10 +2050,12 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1582,6 +2104,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1603,10 +2126,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1643,25 +2167,28 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/immutable": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
-      "integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==",
-      "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1680,18 +2207,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
@@ -1720,30 +2235,25 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1761,7 +2271,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1810,7 +2321,8 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -1823,11 +2335,27 @@
       "link": true
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/minimatch": {
@@ -1835,6 +2363,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1849,15 +2378,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1871,14 +2401,13 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -1944,6 +2473,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1965,20 +2495,24 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -1987,9 +2521,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2004,10 +2538,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2040,40 +2575,23 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
       "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/resolve-from": {
@@ -2081,27 +2599,19 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.0.tgz",
+      "integrity": "sha512-+4C/cgJ9w6sudisA0nZz0+O7lTP9a3CzNLsoDwaRumM8QHwghUsu6tqHXiTmNUp/rqNiM14++7dkzHDyCRs0Jg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2111,56 +2621,37 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
+        "@rollup/rollup-android-arm-eabi": "4.34.0",
+        "@rollup/rollup-android-arm64": "4.34.0",
+        "@rollup/rollup-darwin-arm64": "4.34.0",
+        "@rollup/rollup-darwin-x64": "4.34.0",
+        "@rollup/rollup-freebsd-arm64": "4.34.0",
+        "@rollup/rollup-freebsd-x64": "4.34.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.0",
+        "@rollup/rollup-linux-arm64-musl": "4.34.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.0",
+        "@rollup/rollup-linux-x64-gnu": "4.34.0",
+        "@rollup/rollup-linux-x64-musl": "4.34.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.0",
+        "@rollup/rollup-win32-x64-msvc": "4.34.0",
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/sass": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
-      "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
+      "version": "1.83.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
+      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -2168,13 +2659,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2187,6 +2682,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2199,28 +2695,18 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2228,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -2247,17 +2734,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -2294,6 +2777,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -2305,20 +2789,21 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
-      "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.20.1",
-        "postcss": "^8.4.38",
-        "rollup": "^4.13.0"
+        "esbuild": "^0.24.2",
+        "postcss": "^8.4.49",
+        "rollup": "^4.23.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2327,16 +2812,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -2348,6 +2840,9 @@
         "sass": {
           "optional": true
         },
+        "sass-embedded": {
+          "optional": true
+        },
         "stylus": {
           "optional": true
         },
@@ -2356,19 +2851,26 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
     "node_modules/vue": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
-      "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.27",
-        "@vue/compiler-sfc": "3.4.27",
-        "@vue/runtime-dom": "3.4.27",
-        "@vue/server-renderer": "3.4.27",
-        "@vue/shared": "3.4.27"
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-sfc": "3.5.13",
+        "@vue/runtime-dom": "3.5.13",
+        "@vue/server-renderer": "3.5.13",
+        "@vue/shared": "3.5.13"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2380,10 +2882,11 @@
       }
     },
     "node_modules/vue-eslint-parser": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz",
-      "integrity": "sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
+      "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "eslint-scope": "^7.1.1",
@@ -2408,6 +2911,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -2424,6 +2928,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -2441,6 +2946,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loupedeck-web-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Example on using Loupedeck via WebSerial",
   "scripts": {
     "dev": "vite --force",
@@ -11,17 +11,17 @@
   "author": "Ivo Janssen <hello@ivo.la>",
   "license": "MIT",
   "devDependencies": {
-    "@appliedminds/eslint-config": "^2.0.1",
-    "@vitejs/plugin-vue": "^5.0.4",
-    "eslint": "^9.3.0",
-    "eslint-plugin-vue": "^9.26.0",
-    "sass": "^1.77.2",
-    "vite": "^5.2.11"
+    "@appliedminds/eslint-config": "^2.0.2",
+    "@vitejs/plugin-vue": "^5.2.1",
+    "eslint": "^9.19.0",
+    "eslint-plugin-vue": "^9.32.0",
+    "sass": "^1.83.4",
+    "vite": "^6.0.11"
   },
   "dependencies": {
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "loupedeck": "file:../..",
-    "vue": "^3.4.27"
+    "vue": "^3.5.13"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,23 @@
 {
   "name": "loupedeck",
-  "version": "6.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loupedeck",
-      "version": "6.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "color-rgba": "^3.0.0",
         "events": "^3.3.0",
         "serialport": "^12.0.0",
-        "strict-event-emitter": "^0.5.1",
         "ws": "^8.17.0"
       },
       "devDependencies": {
         "@appliedminds/eslint-config": "^2.0.1",
-        "eslint": "^9.4.0",
-        "eslint-plugin-jest": "^28.6.0",
+        "eslint": "^9.3.0",
+        "eslint-plugin-jest": "^28.5.0",
         "jest": "^29.7.0"
       },
       "engines": {
@@ -741,20 +740,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/config-array": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.15.1.tgz",
-      "integrity": "sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -779,21 +764,26 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
-      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.3.0.tgz",
+      "integrity": "sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/object-schema": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.3.tgz",
-      "integrity": "sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==",
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": ">=10.10.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -808,6 +798,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.3.0",
@@ -2535,16 +2531,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.4.0.tgz",
-      "integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.3.0.tgz",
+      "integrity": "sha512-5Iv4CsZW030lpUqHBapdPo3MJetAPtejVW8B84GIcIIv8+ohFaddXsrn1Gn8uD9ijDb+kcYKFUVmC8qG8B2ORQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/config-array": "^0.15.1",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.4.0",
+        "@eslint/js": "9.3.0",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2586,9 +2582,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.6.0.tgz",
-      "integrity": "sha512-YG28E1/MIKwnz+e2H7VwYPzHUYU4aMa19w0yGcwXnnmJH6EfgHahTJ2un3IyraUxNfnz/KUhJAFXNNwWPo12tg==",
+      "version": "28.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
+      "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
@@ -5112,11 +5108,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,29 @@
 {
   "name": "loupedeck",
-  "version": "5.1.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loupedeck",
-      "version": "5.1.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "color-rgba": "^3.0.0",
         "events": "^3.3.0",
-        "serialport": "^12.0.0",
+        "serialport": "^13.0.0",
         "strict-event-emitter": "^0.5.1",
-        "ws": "^8.17.0"
+        "ws": "^8.18.0"
       },
       "devDependencies": {
-        "@appliedminds/eslint-config": "^2.0.1",
-        "eslint": "^9.4.0",
-        "eslint-plugin-jest": "^28.6.0",
-        "jest": "^29.7.0"
+        "@appliedminds/eslint-config": "^2.0.2",
+        "eslint": "^9.19.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0-rc3"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -42,680 +40,20 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@appliedminds/eslint-config": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@appliedminds/eslint-config/-/eslint-config-2.0.1.tgz",
-      "integrity": "sha512-bViUcyzuOw3nvd33nuP9P63oXMlQYFdWRUvYgTg+mFunE+15ezjFDSIwkB05VtWnwBSmXzeZiCN1BFrElFGGEw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@appliedminds/eslint-config/-/eslint-config-2.0.2.tgz",
+      "integrity": "sha512-sv+W113zOc3UKumP03mXBcZR2/rhUYazy6tqZioTdrEWWWO0Uf/qb3sP+TsOgGxHjdctV4LaH736g0TPWQO0YQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.0.0"
+        "@eslint/js": "^9.13.0",
+        "globals": "^15.11.0"
       },
       "peerDependencies": {
         "eslint": ">=9.0.0",
         "eslint-plugin-vue": ">=9.0.0"
       }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
-      "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
-      "dev": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.4.tgz",
-      "integrity": "sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.23.4",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.4.tgz",
-      "integrity": "sha512-HfcMizYz10cr3h29VqyfGL6ZWIjTwWfvYBMsBVGwpcbhNGe3wQ1ZXZRPzZoAHhd9OqHadHqjQ89iVKINXnbzuw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.4",
-        "@babel/types": "^7.23.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
-      "integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-bigint": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-meta": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.4.tgz",
-      "integrity": "sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.23.4",
-        "@babel/generator": "^7.23.4",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.4",
-        "@babel/types": "^7.23.4",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.4.tgz",
-      "integrity": "sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -733,33 +71,49 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.15.1.tgz",
-      "integrity": "sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.3",
+        "@eslint/object-schema": "^2.1.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -778,22 +132,89 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
-      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.3.tgz",
-      "integrity": "sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
+      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.10.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -810,532 +231,17 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/reporters": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.7.0",
-        "jest-config": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-resolve-dependencies": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/environment": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-      "dev": true,
-      "dependencies": {
-        "expect": "^29.7.0",
-        "jest-snapshot": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
-      "dependencies": {
-        "jest-get-type": "^29.6.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "*",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/globals": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/reporters": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-      "dev": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/source-map": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-result": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@serialport/binding-mock": {
@@ -1351,28 +257,30 @@
       }
     },
     "node_modules/@serialport/bindings-cpp": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-12.0.1.tgz",
-      "integrity": "sha512-r2XOwY2dDvbW7dKqSPIk2gzsr6M6Qpe9+/Ngs94fNaNlcTRCV02PfaoDmRgcubpNVVcLATlxSxPTIDw12dbKOg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-13.0.0.tgz",
+      "integrity": "sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
-        "@serialport/parser-readline": "11.0.0",
-        "debug": "4.3.4",
-        "node-addon-api": "7.0.0",
-        "node-gyp-build": "4.6.0"
+        "@serialport/parser-readline": "12.0.0",
+        "debug": "4.4.0",
+        "node-addon-api": "8.3.0",
+        "node-gyp-build": "4.8.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-11.0.0.tgz",
-      "integrity": "sha512-aZLJhlRTjSmEwllLG7S4J8s8ctRAS0cbvCpO87smLvl3e4BgzbVgF6Z6zaJd3Aji2uSiYgfedCdNc4L6W+1E2g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
+      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1381,11 +289,12 @@
       }
     },
     "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-11.0.0.tgz",
-      "integrity": "sha512-rRAivhRkT3YO28WjmmG4FQX6L+KMb5/ikhyylRfzWPw0nSXy97+u07peS9CbHqaNvJkMhH1locp2H36aGMOEIA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
+      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
+      "license": "MIT",
       "dependencies": {
-        "@serialport/parser-delimiter": "11.0.0"
+        "@serialport/parser-delimiter": "12.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1403,369 +312,161 @@
       }
     },
     "node_modules/@serialport/parser-byte-length": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-12.0.0.tgz",
-      "integrity": "sha512-0ei0txFAj+s6FTiCJFBJ1T2hpKkX8Md0Pu6dqMrYoirjPskDLJRgZGLqoy3/lnU1bkvHpnJO+9oJ3PB9v8rNlg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
+      "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-cctalk": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-12.0.0.tgz",
-      "integrity": "sha512-0PfLzO9t2X5ufKuBO34DQKLXrCCqS9xz2D0pfuaLNeTkyGUBv426zxoMf3rsMRodDOZNbFblu3Ae84MOQXjnZw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-13.0.0.tgz",
+      "integrity": "sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-delimiter": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
-      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
+      "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-inter-byte-timeout": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-12.0.0.tgz",
-      "integrity": "sha512-GnCh8K0NAESfhCuXAt+FfBRz1Cf9CzIgXfp7SdMgXwrtuUnCC/yuRTUFWRvuzhYKoAo1TL0hhUo77SFHUH1T/w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-13.0.0.tgz",
+      "integrity": "sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-packet-length": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-12.0.0.tgz",
-      "integrity": "sha512-p1hiCRqvGHHLCN/8ZiPUY/G0zrxd7gtZs251n+cfNTn+87rwcdUeu9Dps3Aadx30/sOGGFL6brIRGK4l/t7MuQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-13.0.0.tgz",
+      "integrity": "sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6.0"
       }
     },
     "node_modules/@serialport/parser-readline": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
-      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
+      "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
+      "license": "MIT",
       "dependencies": {
-        "@serialport/parser-delimiter": "12.0.0"
+        "@serialport/parser-delimiter": "13.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-ready": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-12.0.0.tgz",
-      "integrity": "sha512-ygDwj3O4SDpZlbrRUraoXIoIqb8sM7aMKryGjYTIF0JRnKeB1ys8+wIp0RFMdFbO62YriUDextHB5Um5cKFSWg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-13.0.0.tgz",
+      "integrity": "sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-regex": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-12.0.0.tgz",
-      "integrity": "sha512-dCAVh4P/pZrLcPv9NJ2mvPRBg64L5jXuiRxIlyxxdZGH4WubwXVXY/kBTihQmiAMPxbT3yshSX8f2+feqWsxqA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-13.0.0.tgz",
+      "integrity": "sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-slip-encoder": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-12.0.0.tgz",
-      "integrity": "sha512-0APxDGR9YvJXTRfY+uRGhzOhTpU5akSH183RUcwzN7QXh8/1jwFsFLCu0grmAUfi+fItCkR+Xr1TcNJLR13VNA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-13.0.0.tgz",
+      "integrity": "sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-spacepacket": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-12.0.0.tgz",
-      "integrity": "sha512-dozONxhPC/78pntuxpz/NOtVps8qIc/UZzdc/LuPvVsqCoJXiRxOg6ZtCP/W58iibJDKPZPAWPGYeZt9DJxI+Q==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-13.0.0.tgz",
+      "integrity": "sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/stream": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-12.0.0.tgz",
-      "integrity": "sha512-9On64rhzuqKdOQyiYLYv2lQOh3TZU/D3+IWCR5gk0alPel2nwpp4YwDEGiUBfrQZEdQ6xww0PWkzqth4wqwX3Q==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
+      "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
+      "license": "MIT",
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
-        "debug": "4.3.4"
+        "debug": "4.4.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
-    },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
+      "license": "MIT"
     },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.6.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
-      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
-      "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.20.7"
-      }
-    },
-    "node_modules/@types/graceful-fs": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "20.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
-      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.10.0.tgz",
-      "integrity": "sha512-7L01/K8W/VGl7noe2mgH0K7BE29Sq6KAbVmxurj8GGaPDZXPr8EEQ2seOeAS+mEV9DnzxBQB6ax6qQQ5C6P4xg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.10.0",
-        "@typescript-eslint/visitor-keys": "7.10.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
-      "integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
-      "integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.10.0",
-        "@typescript-eslint/visitor-keys": "7.10.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
-      "integrity": "sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.10.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1782,24 +483,12 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1809,42 +498,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1862,177 +515,53 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/transform": "^29.7.0",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.6.3",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "dev": true,
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -2045,124 +574,72 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-      "dev": true,
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
           "type": "github",
-          "url": "https://github.com/sponsors/ai"
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
     },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001564",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-      "integrity": "sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
     },
     "node_modules/canvas": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "version": "3.0.0-rc3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.0.0-rc3.tgz",
+      "integrity": "sha512-LJVkMp4AH7/IRoLvhLS6R09uBt9O3O0mhCYL34AQV/+OC39jmTv22pJTF5Mgfa3V2JnzGl21MVrhEKmtmPtfQA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
         "simple-get": "^3.0.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^18.12.0 || >= 20.9.0"
       }
+    },
+    "node_modules/canvas/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2180,75 +657,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
       "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-      "dev": true
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
-      "dev": true
+      "peer": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2298,61 +713,18 @@
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
       "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/create-jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "prompts": "^2.0.1"
-      },
-      "bin": {
-        "create-jest": "bin/create-jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2376,11 +748,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2404,18 +777,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/dedent": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-      "dev": true,
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2424,102 +794,26 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.4.594",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.594.tgz",
-      "integrity": "sha512-xT1HVAu5xFn7bDfkjGQi9dNpMqGchUkebwf1GL7cZN32NSwwlHRPMSDJ1KN6HkS0bWUtndbSQZqvpQftKG2uFQ==",
-      "dev": true
-    },
-    "node_modules/emittery": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
+        "once": "^1.4.0"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2535,28 +829,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.4.0.tgz",
-      "integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
+      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/config-array": "^0.15.1",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.4.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.10.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.19.0",
+        "@eslint/plugin-kit": "^0.2.5",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.0",
-        "@nodelib/fs.walk": "^1.2.8",
+        "@humanwhocodes/retry": "^0.4.1",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.0.1",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.0.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -2565,15 +864,11 @@
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -2582,54 +877,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest": {
-      "version": "28.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.6.0.tgz",
-      "integrity": "sha512-YG28E1/MIKwnz+e2H7VwYPzHUYU4aMa19w0yGcwXnnmJH6EfgHahTJ2un3IyraUxNfnz/KUhJAFXNNwWPo12tg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
-      },
-      "engines": {
-        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+        "url": "https://eslint.org/donate"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0",
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "jest": "*"
+        "jiti": "*"
       },
       "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "jest": {
+        "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.10.0.tgz",
-      "integrity": "sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.10.0",
-        "@typescript-eslint/types": "7.10.0",
-        "@typescript-eslint/typescript-estree": "7.10.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
       }
     },
     "node_modules/eslint-plugin-vue": {
@@ -2672,10 +928,11 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.1.tgz",
-      "integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -2700,10 +957,11 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2712,14 +970,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.11.3",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.0.0"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2729,28 +988,16 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -2803,117 +1050,36 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">=6"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
-      "dependencies": {
-        "bser": "2.1.1"
-      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2925,18 +1091,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2974,148 +1128,21 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "devOptional": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "peer": true
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -3130,42 +1157,17 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3176,59 +1178,34 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
       "optional": true,
       "peer": true
     },
-    "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -3238,31 +1215,13 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-local": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
-      "dev": true,
-      "dependencies": {
-        "pkg-dir": "^4.2.0",
-        "resolve-cwd": "^3.0.0"
-      },
-      "bin": {
-        "import-local-fixture": "fixtures/cli.js"
-      },
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3277,39 +1236,21 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "devOptional": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
-    },
-    "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3318,24 +1259,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-glob": {
@@ -3350,691 +1273,24 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
-      "dev": true,
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "import-local": "^3.0.2",
-        "jest-cli": "^29.7.0"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-changed-files": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
-      "dev": true,
-      "dependencies": {
-        "execa": "^5.0.0",
-        "jest-util": "^29.7.0",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-circus": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^1.0.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.7.0",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^29.7.0",
-        "pure-rand": "^6.0.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "create-jest": "^29.7.0",
-        "exit": "^0.1.2",
-        "import-local": "^3.0.2",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-config": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-jest": "^29.7.0",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-docblock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "dev": true,
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-each": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-leak-detector": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-      "dev": true,
-      "dependencies": {
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^2.0.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve-dependencies": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-      "dev": true,
-      "dependencies": {
-        "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/environment": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-leak-detector": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-resolve": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/globals": "^29.7.0",
-        "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-jsx": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^29.7.0",
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "leven": "^3.1.0",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-watcher": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-      "dev": true,
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "jest-util": "^29.7.0",
-        "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "license": "ISC"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/json-buffer": {
@@ -4043,35 +1299,18 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4080,24 +1319,6 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -4112,12 +1333,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4147,76 +1362,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/makeerror": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
-      "dependencies": {
-        "tmpl": "1.0.5"
-      }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
@@ -4234,7 +1379,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4242,72 +1387,36 @@
         "node": "*"
       }
     },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
-    "node_modules/nan": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
@@ -4317,103 +1426,38 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-addon-api": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
-      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "node_modules/node-abi": {
+      "version": "3.73.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.73.0.tgz",
+      "integrity": "sha512-z8iYzQGBu35ZkTQ9mtR8RqugJZ9RCLn8fv3d7LsgDBzOijGQP3RdKTX4LA7LXw03ZhU5z0l4xfhIMgSES31+cg==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-      "dev": true
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -4429,38 +1473,14 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -4510,43 +1530,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -4558,126 +1552,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4696,217 +1576,69 @@
         "node": ">=4"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ]
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
       },
       "bin": {
-        "resolve": "bin/resolve"
+        "prebuild-install": "bin.js"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-cwd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-cwd/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/resolve.exports": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+    "node_modules/prebuild-install/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "mimic-response": "^3.1.0"
       },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
+    "node_modules/prebuild-install/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "funding": [
         {
           "type": "github",
@@ -4921,8 +1653,98 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "queue-microtask": "^1.2.2"
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/safe-buffer": {
@@ -4943,6 +1765,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
@@ -4951,6 +1774,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4959,44 +1783,39 @@
       }
     },
     "node_modules/serialport": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-12.0.0.tgz",
-      "integrity": "sha512-AmH3D9hHPFmnF/oq/rvigfiAouAKyK/TjnrkwZRYSFZxNggJxwvbAbfYrLeuvq7ktUdhuHdVdSjj852Z55R+uA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-13.0.0.tgz",
+      "integrity": "sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==",
+      "license": "MIT",
       "dependencies": {
         "@serialport/binding-mock": "10.2.2",
-        "@serialport/bindings-cpp": "12.0.1",
-        "@serialport/parser-byte-length": "12.0.0",
-        "@serialport/parser-cctalk": "12.0.0",
-        "@serialport/parser-delimiter": "12.0.0",
-        "@serialport/parser-inter-byte-timeout": "12.0.0",
-        "@serialport/parser-packet-length": "12.0.0",
-        "@serialport/parser-readline": "12.0.0",
-        "@serialport/parser-ready": "12.0.0",
-        "@serialport/parser-regex": "12.0.0",
-        "@serialport/parser-slip-encoder": "12.0.0",
-        "@serialport/parser-spacepacket": "12.0.0",
-        "@serialport/stream": "12.0.0",
-        "debug": "4.3.4"
+        "@serialport/bindings-cpp": "13.0.0",
+        "@serialport/parser-byte-length": "13.0.0",
+        "@serialport/parser-cctalk": "13.0.0",
+        "@serialport/parser-delimiter": "13.0.0",
+        "@serialport/parser-inter-byte-timeout": "13.0.0",
+        "@serialport/parser-packet-length": "13.0.0",
+        "@serialport/parser-readline": "13.0.0",
+        "@serialport/parser-ready": "13.0.0",
+        "@serialport/parser-regex": "13.0.0",
+        "@serialport/parser-slip-encoder": "13.0.0",
+        "@serialport/parser-spacepacket": "13.0.0",
+        "@serialport/stream": "13.0.0",
+        "debug": "4.4.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5009,15 +1828,10 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "devOptional": true
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -5052,67 +1866,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
@@ -5122,67 +1875,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5190,6 +1887,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -5209,107 +1907,50 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+    "node_modules/tar-fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
       }
     },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
       "optional": true,
-      "peer": true
-    },
-    "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
       "optional": true,
-      "peer": true
-    },
-    "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -5322,15 +1963,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -5346,61 +1978,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5411,20 +1994,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "devOptional": true,
       "peer": true
-    },
-    "node_modules/v8-to-istanbul": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.2",
@@ -5486,38 +2055,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/walker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
-      "dependencies": {
-        "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5528,56 +2071,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true
-    },
-    "node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
+      "optional": true,
+      "peer": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5600,48 +2105,6 @@
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
       "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,13 @@
         "color-rgba": "^3.0.0",
         "events": "^3.3.0",
         "serialport": "^12.0.0",
+        "strict-event-emitter": "^0.5.1",
         "ws": "^8.17.0"
       },
       "devDependencies": {
         "@appliedminds/eslint-config": "^2.0.1",
-        "eslint": "^9.3.0",
-        "eslint-plugin-jest": "^28.5.0",
+        "eslint": "^9.4.0",
+        "eslint-plugin-jest": "^28.6.0",
         "jest": "^29.7.0"
       },
       "engines": {
@@ -740,6 +741,20 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/config-array": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.15.1.tgz",
+      "integrity": "sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -764,26 +779,21 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.3.0.tgz",
-      "integrity": "sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
+      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.3.tgz",
+      "integrity": "sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==",
       "dev": true,
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
-      },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -798,12 +808,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "dev": true
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.3.0",
@@ -2531,16 +2535,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.3.0.tgz",
-      "integrity": "sha512-5Iv4CsZW030lpUqHBapdPo3MJetAPtejVW8B84GIcIIv8+ohFaddXsrn1Gn8uD9ijDb+kcYKFUVmC8qG8B2ORQ==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.4.0.tgz",
+      "integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/config-array": "^0.15.1",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.3.0",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint/js": "9.4.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2582,9 +2586,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
-      "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
+      "version": "28.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.6.0.tgz",
+      "integrity": "sha512-YG28E1/MIKwnz+e2H7VwYPzHUYU4aMa19w0yGcwXnnmJH6EfgHahTJ2un3IyraUxNfnz/KUhJAFXNNwWPo12tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
@@ -5108,6 +5112,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "author": "Ivo Janssen <hello@ivo.la>",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "devDependencies": {
     "@appliedminds/eslint-config": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "lint": "eslint",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --test  --experimental-test-coverage --experimental-test-module-mocks"
   },
   "files": [
     "index.js",
@@ -20,24 +20,17 @@
   "dependencies": {
     "color-rgba": "^3.0.0",
     "events": "^3.3.0",
-    "serialport": "^12.0.0",
+    "serialport": "^13.0.0",
     "strict-event-emitter": "^0.5.1",
-    "ws": "^8.17.0"
+    "ws": "^8.18.0"
   },
   "peerDependencies": {
-    "canvas": "^2.11.2"
+    "canvas": "^3.0.0-rc3"
   },
   "peerDependenciesMeta": {
     "canvas": {
       "optional": true
     }
-  },
-  "jest": {
-    "collectCoverage": true,
-    "coverageReporters": [
-      "text"
-    ],
-    "verbose": true
   },
   "keywords": [
     "loupedeck",
@@ -61,9 +54,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@appliedminds/eslint-config": "^2.0.1",
-    "eslint": "^9.4.0",
-    "eslint-plugin-jest": "^28.6.0",
-    "jest": "^29.7.0"
+    "@appliedminds/eslint-config": "^2.0.2",
+    "eslint": "^9.19.0"
   }
 }

--- a/test/connection-serial.test.js
+++ b/test/connection-serial.test.js
@@ -1,6 +1,10 @@
-import { jest } from '@jest/globals'
-import * as serialport from '../__mocks__/serialport.js'
-jest.unstable_mockModule('serialport', () => serialport)
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
+
+import { MockSerialPort } from '../__mocks__/serialport.js'
+mock.module('serialport', {
+    namedExports: { SerialPort: MockSerialPort }
+})
 const { SerialPort } = await import('serialport')
 const SerialConnection = (await import('../connections/serial.js')).default
 
@@ -8,63 +12,63 @@ let connection
 
 describe('v0.2.X Connection', () => {
     it('auto-discovers valid connections', async() => {
-        expect(await SerialConnection.discover()).toEqual([{ connectionType: SerialConnection, path: '/dev/cu.usbmodem-333', productId: 0x0004, serialNumber: 'LDD12345678', vendorId: 0x2ec2 }])
+        assert.deepEqual(await SerialConnection.discover(), [{ connectionType: SerialConnection, path: '/dev/cu.usbmodem-333', productId: 0x0004, serialNumber: 'LDD12345678', vendorId: 0x2ec2 }])
     })
     it('connects via direct instantiation', async() => {
         connection = new SerialConnection({ path: '/dev/fake-path' })
-        const fn = jest.fn()
+        const fn = mock.fn()
         connection.on('connect', fn)
         await connection.connect()
-        expect(fn).toHaveBeenCalledWith({ address: '/dev/fake-path' })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { address: '/dev/fake-path' })
         connection.close()
     })
     it('prepends small outgoing messages', async() => {
         connection = new SerialConnection()
         await connection.connect()
-        const sender = jest.spyOn(connection.connection, 'write')
+        const sender = mock.method(connection.connection, 'write')
         const TEST_MESSAGE = Buffer.from([0x88])
         connection.send(TEST_MESSAGE)
-        expect(sender).toHaveBeenCalledTimes(2)
-        expect(sender).toHaveBeenCalledWith(Buffer.from([0x82, 0x81, 0x00, 0x00, 0x00, 0x00]))
-        expect(sender).toHaveBeenCalledWith(TEST_MESSAGE)
+        assert.equal(sender.mock.calls.length, 2)
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from([0x82, 0x81, 0x00, 0x00, 0x00, 0x00]))
+        assert.equal(sender.mock.calls[1].arguments[0], TEST_MESSAGE)
         connection.close()
     })
     it('prepends large outgoing messages', async() => {
         connection = new SerialConnection()
         await connection.connect()
-        const sender = jest.spyOn(connection.connection, 'write')
+        const sender = mock.method(connection.connection, 'write')
         const TEST_MESSAGE = Buffer.alloc(4000).fill(0xff)
         connection.send(TEST_MESSAGE)
-        expect(sender).toHaveBeenCalledTimes(2)
-        expect(sender).toHaveBeenCalledWith(Buffer.from([0x82, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0xa0, 0x00, 0x00, 0x00, 0x00]))
-        expect(sender).toHaveBeenCalledWith(TEST_MESSAGE)
+        assert.equal(sender.mock.calls.length, 2)
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from([0x82, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0xa0, 0x00, 0x00, 0x00, 0x00]))
+        assert.equal(sender.mock.calls[1].arguments[0], TEST_MESSAGE)
         connection.close()
     })
     it('reports ready to receive', async() => {
         connection = new SerialConnection()
-        expect(connection.isReady()).toBe(false)
+        assert.equal(connection.isReady(), false)
         await connection.connect()
-        expect(connection.isReady()).toBe(true)
+        assert.equal(connection.isReady(), true)
         connection.close()
     })
     it('reports on connection failure', async() => {
-        const mockWriter = jest.spyOn(SerialPort.prototype, 'write').mockImplementation(function() {
+        const mockWriter = mock.method(SerialPort.prototype, 'write', function() {
             this.emit('data', 'nonsense')
         })
         connection = new SerialConnection()
-        await expect(connection.connect()).rejects.toMatch(/Invalid handshake/)
-        mockWriter.mockRestore()
+        await assert.rejects(() => connection.connect(), /Invalid handshake/i)
+        mockWriter.mock.restore()
     })
     it('reports connection errors', async() => {
-        const logger = jest.spyOn(console, 'error')
+        const logger = mock.method(console, 'error')
         connection = new SerialConnection()
         await connection.connect()
-        const mockWriter = jest.spyOn(connection.connection, 'write').mockImplementation(function() {
+        const mockWriter = mock.method(connection.connection, 'write', function() {
             this.emit('error', new Error('write error'))
         })
         connection.send(Buffer.from([0xff]))
-        expect(logger).toHaveBeenCalledWith(expect.stringMatching(/write error/))
+        assert.match(logger.mock.calls[0].arguments[0], /write error/i)
         connection.close()
-        mockWriter.mockRestore()
+        mockWriter.mock.restore()
     })
 })

--- a/test/connection-ws.test.js
+++ b/test/connection-ws.test.js
@@ -1,7 +1,9 @@
-import { jest } from '@jest/globals'
-import * as mockWS from '../__mocks__/ws.js'
-jest.unstable_mockModule('ws', () => mockWS)
-jest.unstable_mockModule('node:os', () => ({ networkInterfaces: jest.fn() }))
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
+
+import { MockSocket } from '../__mocks__/ws.js'
+mock.module('ws', { defaultExport: MockSocket })
+mock.module('node:os', { namedExports: { networkInterfaces: mock.fn() } })
 const os = await import('node:os')
 const WSConnection = (await import('../connections/ws.js')).default
 
@@ -11,63 +13,63 @@ let connection
 
 describe('v0.1.X Connection', () => {
     it('auto-discovers valid connections', async() => {
-        os.networkInterfaces.mockReturnValue([{ address: '255.255.255.255' }])
-        expect(await WSConnection.discover()).toEqual([])
-        os.networkInterfaces.mockReturnValue([{ address: '100.127.80.1' }])
-        expect(await WSConnection.discover()).toEqual([expect.objectContaining({ connectionType: WSConnection, host: '100.127.80.1' })])
+        os.networkInterfaces.mock.mockImplementationOnce(() => [{ address: '255.255.255.255' }])
+        assert.deepEqual(await WSConnection.discover(), [])
+        os.networkInterfaces.mock.mockImplementationOnce(() => [{ address: '100.127.80.1' }])
+        assert.deepEqual(await WSConnection.discover(), [{ connectionType: WSConnection, host: '100.127.80.1', productId: 4 }])
     })
     it('connects via direct instantiation', async() => {
         connection = new WSConnection({ host: '127.0.0.1' })
-        const fn = jest.fn()
+        const fn = mock.fn()
         connection.on('connect', fn)
         await connection.connect()
-        expect(fn).toHaveBeenCalledWith({ address: 'ws://127.0.0.1' })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { address: 'ws://127.0.0.1' })
         connection.close()
     })
     it('keeps connection alive when ticks received', async() => {
         connection = new WSConnection()
-        const fn = jest.fn()
+        const fn = mock.fn()
         connection.on('disconnect', fn)
         connection.connectionTimeout = 20
-        const connect = jest.spyOn(connection, 'connect')
+        const connect = mock.method(connection, 'connect')
         await connection.connect()
         for (let i = 0; i < 8; i++) {
             await delay(10)
             connection.onReceive()
         }
-        expect(fn).not.toHaveBeenCalled()
-        expect(connect).toHaveBeenCalledTimes(1)
+        assert.equal(fn.mock.calls.length, 0)
+        assert.equal(connect.mock.calls.length, 1)
     })
     it('disconnects on timeout', async() => {
         connection = new WSConnection()
-        const keepAliveCheck = jest.spyOn(connection, 'checkConnected')
-        const fn = jest.fn()
+        const keepAliveCheck = mock.method(connection, 'checkConnected')
+        const fn = mock.fn()
         connection.on('disconnect', fn)
         connection.connectionTimeout = 20
         await connection.connect()
         await delay(80)
-        expect(fn.mock.calls[0][0].message).toMatch(/connection timeout/i)
-        expect(keepAliveCheck.mock.calls.length).toEqual(1)
+        assert.match(fn.mock.calls[0].arguments[0].message, /connection timeout/i)
+        assert.equal(keepAliveCheck.mock.calls.length, 1)
     })
     it('delegates messages', async() => {
         connection = new WSConnection()
         await connection.connect()
-        const sender = jest.spyOn(connection.connection, 'send')
+        const sender = mock.method(connection.connection, 'send')
         const TEST_MESSAGE = Buffer.from([0x88])
         connection.send(TEST_MESSAGE)
-        expect(sender).toHaveBeenCalledWith(TEST_MESSAGE)
+        assert.equal(sender.mock.calls[0].arguments[0], TEST_MESSAGE)
         connection.close()
     })
     it('reports ready to receive', async() => {
         connection = new WSConnection()
-        expect(connection.isReady()).toBe(false)
+        assert.equal(connection.isReady(), false)
         await connection.connect()
-        expect(connection.isReady()).toBe(true)
+        assert.equal(connection.isReady(), true)
         connection.close()
     })
     it('can close even when not connected', () => {
         connection = new WSConnection()
         connection.close()
-        expect(connection.connection).toBe(undefined)
+        assert.equal(connection.connection, undefined)
     })
 })

--- a/test/device-ct.test.js
+++ b/test/device-ct.test.js
@@ -1,25 +1,26 @@
-import { jest } from '@jest/globals'
-import * as mockWS from '../__mocks__/ws.js'
-import * as serialport from '../__mocks__/serialport.js'
-jest.unstable_mockModule('ws', () => mockWS)
-jest.unstable_mockModule('serialport', () => serialport)
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it, mock } from 'node:test'
+
+import { MockSocket } from '../__mocks__/ws.js'
+import { MockSerialPort } from '../__mocks__/serialport.js'
+mock.module('ws', { defaultExport: MockSocket })
+mock.module('serialport', {
+    namedExports: { SerialPort: MockSerialPort }
+})
 const SerialConnection = (await import('../connections/serial.js')).default
 const WSConnection = (await import('../connections/ws.js')).default
 const { LoupedeckCT } = await import('../index.js')
 
-expect.extend({
-    toBePixelBuffer(received, { displayID, x, y, width, height }) {
-        if (received.readUInt16BE(0) !== 0xff10) return { pass: false, message: () => `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}` }
-        if (received.readUInt16BE(3) !== displayID) return { pass: false, message: () => `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}` }
-        if (received.readUInt16BE(5) !== x) return { pass: false, message: () => `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}` }
-        if (received.readUInt16BE(7) !== y) return { pass: false, message: () => `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}` }
-        if (received.readUInt16BE(9) !== width) return { pass: false, message: () => `Width should be ${width}, but found ${received.readUInt16BE(9)}` }
-        if (received.readUInt16BE(11) !== height) return { pass: false, message: () => `Height should be ${height}, but found ${received.readUInt16BE(11)}` }
-        const correctLength = 13 + width * height * 2
-        if (received.length !== correctLength) return { pass: false, message: () => `Buffer length should be ${correctLength}, but found ${received.length}` }
-        return { pass: true }
-    }
-})
+function assertIsPixelBuffer(received, { displayID, x, y, width, height }) {
+    assert(received.readUInt16BE(0) === 0xff10, `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}`)
+    assert(received.readUInt16BE(3) === displayID, `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}`)
+    assert(received.readUInt16BE(5) === x, `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}`)
+    assert(received.readUInt16BE(7) === y, `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}`)
+    assert(received.readUInt16BE(9) === width, `Width should be ${width}, but found ${received.readUInt16BE(9)}`)
+    assert(received.readUInt16BE(11) === height, `Height should be ${height}, but found ${received.readUInt16BE(11)}`)
+    const correctLength = 13 + width * height * 2
+    assert(received.length === correctLength, `Buffer length should be ${correctLength}, but found ${received.length}`)
+}
 
 const delay = ms => new Promise(res => setTimeout(res, ms))
 
@@ -31,14 +32,14 @@ describe('Commands', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('retrieves device information', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030301', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex'))
         await delay(20)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030702', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c0702000208000900000000', 'hex'))
-        await expect(promise).resolves.toEqual({
+        assert.deepEqual(await promise, {
             version: '0.2.8',
             serial: 'LDL1101013000396700138A0001'
         })
@@ -46,33 +47,33 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await expect(promise).rejects.toThrow(/not connected/i)
+        await assert.rejects(promise, /not connected/i)
     })
     it('sets brightness', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('04090100', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0409020a', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('sets button color', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setButtonColor({ id: 'enter', color: 'red' })
-        expect(sender).toHaveBeenCalledWith(Buffer.from('07020112ff0000', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('07020112ff0000', 'hex'))
     })
     it('errors on unknown button passed', () => {
-        expect(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
+        assert.throws(() => device.setButtonColor({ id: 'triangle', color: 'blue' }), /Invalid button/i)
     })
     it('vibrates short by default', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0101', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('041b0101', 'hex'))
     })
     it('vibrates a specific pattern', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate(0x56)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0156', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('041b0156', 'hex'))
     })
 })
 describe('Drawing (Callback API)', () => {
@@ -81,7 +82,7 @@ describe('Drawing (Callback API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to left display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('left', (ctx, w, h) => {
             ctx.fillStyle = '#f00' // red
             ctx.fillRect(0, 0, w, h)
@@ -89,15 +90,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so first 5 bits for full red is 0xf800, or 0x00f8 in LE
         const pixels = '00f8'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004c, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004c, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004c', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004c', 'hex'))
     })
     it('writes pixels to right display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('right', (ctx, w, h) => {
             ctx.fillStyle = '#0f0' // green
             ctx.fillRect(0, 0, w, h)
@@ -105,15 +106,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const pixels = 'e007'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0052, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0052, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020052', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020052', 'hex'))
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('center', (ctx, w, h) => {
             ctx.fillStyle = '#00f' // blue
             ctx.fillRect(0, 0, w, h)
@@ -121,15 +122,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(360 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0041, x: 0, y: 0, width: 360, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0041, x: 0, y: 0, width: 360, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020041', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020041', 'hex'))
     })
     it('writes pixels to knob display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('knob', (ctx, w, h) => {
             ctx.fillStyle = '#00f' // blue
             ctx.fillRect(0, 0, w, h)
@@ -137,34 +138,34 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB (Big endian!)
         // so last 5 bits for full blue is 0x001f
         const pixels = '001f'.repeat(240 * 240)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0057, x: 0, y: 0, width: 240, height: 240 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0057, x: 0, y: 0, width: 240, height: 240 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020057', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020057', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawKey(6, (ctx, w, h) => {
             ctx.fillStyle = '#fff'
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0041, x: 180, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0041, x: 180, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020041', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020041', 'hex'))
     })
     it('writes pixels without refreshing the screen', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawCanvas({ id: 'center', width: 10, height: 10, autoRefresh: false }, () => {})
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenCalledTimes(1)
+        assert.equal(sender.mock.calls.length, 1)
     })
 })
 describe('Drawing (Buffer API)', () => {
@@ -173,80 +174,80 @@ describe('Drawing (Buffer API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to left display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(60 * 270).fill([0x00, 0xf8])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('left', buffer)
         const hex = '00f8'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004c, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004c, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004c', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004c', 'hex'))
     })
     it('writes pixels to right display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(60 * 270).fill([0xe0, 0x07])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('right', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const hex = 'e007'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0052, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0052, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020052', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020052', 'hex'))
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(360 * 270).fill([0x1f, 0x00])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('center', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(360 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0041, x: 0, y: 0, width: 360, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0041, x: 0, y: 0, width: 360, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020041', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020041', 'hex'))
     })
     it('writes pixels to knob display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(240 * 240).fill([0x00, 0x1f])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('knob', buffer)
         // Color format is 5-6-5 16-bit RGB (Big endian!)
         // so last 5 bits for full blue is 0x001f
         const hex = '001f'.repeat(240 * 240)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0057, x: 0, y: 0, width: 240, height: 240 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0057, x: 0, y: 0, width: 240, height: 240 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020057', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020057', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(90 * 90 * 2).fill(0xff)
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x0041, x: 180, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x0041, x: 180, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f020041', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f020041', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await expect(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
+        await assert.rejects(() => device.drawScreen('left', buffer), /expected buffer length of 32400, got 30/i)
     })
 })
 
@@ -256,290 +257,307 @@ describe('Message Parsing', () => {
     })
     it('processes timestamp events', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000ba', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).not.toHaveBeenCalled()
+        assert.equal(fn.mock.calls.length, 0)
     })
     it('processes button presses', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000900', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('down', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 2 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 2 })
     })
     it('processes button releases', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000701', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 0 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 0 })
     })
     it('processes clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('0501000101', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 'knobTL', delta: 1 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 'knobTL', delta: 1 })
     })
     it('processes counter-clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('05010000ff', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 'knobCT', delta: -1 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 'knobCT', delta: -1 })
     })
     it('processes initial main screen touches', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e213', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 115, y: 226 })],
-        }))
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 19,
+            target: {
+                key: 8,
+                screen: 'center'
+            },
+            x: 115,
+            y: 226,
+        })
     })
     it('processes initial knob screen touches', () => {
         const SAMPLE_MESSAGE = Buffer.from('095200000096008e00', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 150, y: 142, target: expect.objectContaining({ screen: 'knob' }) })],
-        }))
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 0,
+            x: 150,
+            y: 142,
+            target: { screen: 'knob' },
+        })
     })
     it('processes ticks', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000f9', 'hex')
-        expect(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.doesNotThrow(() => device.onReceive(SAMPLE_MESSAGE))
     })
     it('processes touch moves', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e215', 'hex')
         const FOLLOW_MESSAGE = Buffer.from('094d0000007000e515', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchmove', fn)
         device.onReceive(SAMPLE_MESSAGE)
         device.onReceive(FOLLOW_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 112, y: 229 })],
-        }))
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 21,
+            x: 112,
+            y: 229,
+            target: {
+                key: 8,
+                screen: 'center'
+            }
+        })
     })
     it('processes main screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('096d000001bf004c12', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({
-            touches: [],
-            changedTouches: [expect.objectContaining({ x: 447, y: 76 })],
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 18,
+            target: { screen: 'right' },
+            x: 447,
+            y: 76,
         })
     })
     it('processes knob screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('097200000096008e00', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({
-            touches: [],
-            changedTouches: [expect.objectContaining({ x: 150, y: 142 })],
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 0,
+            target: { screen: 'knob' },
+            x: 150,
+            y: 142,
         })
     })
     it('processes screen and key targets from touch events', () => {
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(Buffer.from('094d00000022008f13', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'left', key: undefined } })],
-        }))
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0].target, {
+            screen: 'left',
+        })
         device.onReceive(Buffer.from('094d00000067004816', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 0 } })],
-        }))
+        assert.deepEqual(fn.mock.calls[1].arguments[0].changedTouches[0].target, {
+            screen: 'center', key: 0,
+        })
         device.onReceive(Buffer.from('094d000000c8008011', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 5 } })],
-        }))
+        assert.deepEqual(fn.mock.calls[2].arguments[0].changedTouches[0].target, {
+            screen: 'center', key: 5,
+        })
         device.onReceive(Buffer.from('094d0000017500d21a', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 11 } })],
-        }))
+        assert.deepEqual(fn.mock.calls[3].arguments[0].changedTouches[0].target, {
+            screen: 'center', key: 11,
+        })
         device.onReceive(Buffer.from('094d000001c200b8ff', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'right', key: undefined } })],
-        }))
+        assert.deepEqual(fn.mock.calls[4].arguments[0].changedTouches[0].target, {
+            screen: 'right',
+        })
     })
     it('processes multiple simultaneous touches', () => {
-        const touchstart = jest.fn()
-        const touchmove = jest.fn()
-        const touchend = jest.fn()
+        const touchstart = mock.fn()
+        const touchmove = mock.fn()
+        const touchend = mock.fn()
         device.on('touchstart', touchstart)
         device.on('touchmove', touchmove)
         device.on('touchend', touchend)
+        let ev
 
         // Multiple starts
         const TOUCH_1_START = Buffer.from('094d000001bf004c01', 'hex')
         const TOUCH_2_START = Buffer.from('094d00000002000102', 'hex')
         device.onReceive(TOUCH_1_START)
-        expect(touchstart).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
-        })
+        ev = touchstart.mock.calls[0].arguments[0]
+        assert.equal(ev.touches.length, 1)
+        assert.equal(ev.changedTouches[0].id, 1)
+
         device.onReceive(TOUCH_2_START)
-        expect(touchstart).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 2 })],
-        })
+        ev = touchstart.mock.calls[1].arguments[0]
+        assert.equal(ev.touches.length, 2)
+        assert.equal(ev.changedTouches[0].id, 2)
 
         // Independent moves
         const TOUCH_1_MOVE = Buffer.from('094d000001bf004f01', 'hex')
         const TOUCH_2_MOVE = Buffer.from('094d00000004000802', 'hex')
         device.onReceive(TOUCH_2_MOVE)
-        expect(touchmove).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 2 })],
-        })
+        ev = touchmove.mock.calls[0].arguments[0]
+        assert.equal(ev.touches.length, 2)
+        assert.equal(ev.changedTouches[0].id, 2)
+
         device.onReceive(TOUCH_1_MOVE)
-        expect(touchmove).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
-        })
+        ev = touchmove.mock.calls[1].arguments[0]
+        assert.equal(ev.touches.length, 2)
+        assert.equal(ev.changedTouches[0].id, 1)
 
         // Remove one touch
         const TOUCH_1_REMOVE = Buffer.from('096d000001bf004f01', 'hex')
         device.onReceive(TOUCH_1_REMOVE)
-        expect(touchend).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
-        })
+        ev = touchend.mock.calls[0].arguments[0]
+        assert.equal(ev.touches.length, 1)
+        assert.equal(ev.changedTouches[0].id, 1)
     })
     it('processes version information', () => {
         const VERSION_PACKET = Buffer.from('0c070201052000ff00000000', 'hex')
-        expect(device.onReceive(VERSION_PACKET)).toEqual('1.5.32')
+        assert.equal(device.onReceive(VERSION_PACKET), '1.5.32')
     })
     it('processes serial information', () => {
         const SERIAL_PACKET = Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex')
-        expect(device.onReceive(SERIAL_PACKET)).toEqual('LDL1101013000396700138A0001')
+        assert.equal(device.onReceive(SERIAL_PACKET), 'LDL1101013000396700138A0001')
     })
     it('ignores unknown messages', () => {
         const SAMPLE_MESSAGE = Buffer.from('ffffffffffffff', 'hex')
-        expect(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.doesNotThrow(() => device.onReceive(SAMPLE_MESSAGE))
     })
 })
 
 describe('Connection Management', () => {
     it('connects to serial first if both connection types are available', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' }
         ])
-        const serialConnect = jest.spyOn(SerialConnection.prototype, 'connect').mockImplementation(function() {
+        const serialConnect = mock.method(SerialConnection.prototype, 'connect', function() {
             this.emit('connect', { address: this.path })
         })
-        const wsDiscovery = jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        const wsDiscovery = mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         device = new LoupedeckCT()
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('connect', fn)
         await device.connect()
-        expect(fn).toHaveBeenCalledWith({ address: '/dev/test1' })
-        serialDiscovery.mockRestore()
-        serialConnect.mockRestore()
-        wsDiscovery.mockRestore()
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { address: '/dev/test1' })
+        serialDiscovery.mock.restore()
+        serialConnect.mock.restore()
+        wsDiscovery.mock.restore()
         device.close()
     })
     it('connects to serial if path explicitly set', () => {
         device = new LoupedeckCT({ path: '/dev/test2' })
-        expect(device.connection).toBeInstanceOf(SerialConnection)
+        assert(device.connection instanceof SerialConnection)
         device.close()
     })
     it('connects to websocket if host explicitly set', () => {
         device = new LoupedeckCT({ host: '255.255.255.255' })
-        expect(device.connection).toBeInstanceOf(WSConnection)
+        assert(device.connection instanceof WSConnection)
         device.close()
     })
     it('attempts reconnect if device not found', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [])
-        const wsDiscovery = jest.spyOn(WSConnection, 'discover').mockImplementation(() => [])
-        const fn = jest.fn()
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [])
+        const wsDiscovery = mock.method(WSConnection, 'discover', () => [])
+        const fn = mock.fn()
         device = new LoupedeckCT({ autoConnect: false, reconnectInterval: 20 })
         device.on('disconnect', fn)
-        const connect = jest.spyOn(device, 'connect')
-        await expect(device.connect()).rejects.toMatch(/no devices found/i)
+        const connect = mock.method(device, 'connect')
+        await assert.rejects(() => device.connect(), /no devices found/i)
         await delay(40)
-        expect(connect.mock.calls.length).toBeGreaterThanOrEqual(2)
-        expect(fn.mock.calls[0][0].message).toMatch(/no devices found/i)
-        serialDiscovery.mockRestore()
-        wsDiscovery.mockRestore()
+        assert(connect.mock.calls.length >= 2)
+        assert.match(fn.mock.calls[0].arguments[0].message, /no devices found/i)
+        serialDiscovery.mock.restore()
+        wsDiscovery.mock.restore()
         device.close()
     })
     it('attempts reconnect on error', async() => {
         device = new LoupedeckCT({ autoConnect: false, reconnectInterval: 20 })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => Promise.reject('some error'))
+        const connect = mock.method(device, 'connect', () => Promise.reject('some error'))
         device.onDisconnect('some error')
         await delay(40)
-        expect(connect).toHaveBeenCalled()
+        assert(connect.mock.calls.length > 0)
         device.close()
     })
     it('does not attempt reconnect if closed before reconnect time', async() => {
         device = new LoupedeckCT({ autoConnect: false, reconnectInterval: 20 })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => {})
+        const connect = mock.method(device, 'connect', () => {})
         device.onDisconnect('some error')
         device.onDisconnect()
         await delay(40)
-        expect(connect).not.toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
     })
     it('does not attempt reconnect if reconnect interval not set', async() => {
         device = new LoupedeckCT({ autoConnect: false, reconnectInterval: false })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => {})
+        const connect = mock.method(device, 'connect', () => {})
         device.onDisconnect('some error')
         await delay(100)
-        expect(connect).not.toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
     })
     it('ignores commands if connection not open', () => {
         device = new LoupedeckCT({ path: '/dev/test3', autoConnect: false })
         device.connection = { send: () => {}, isReady: () => false, close: () => {} }
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.send('test', Buffer.from([0xff]))
-        expect(sender).not.toHaveBeenCalled()
+        assert.equal(sender.mock.calls.length, 0)
         device.close()
     })
     it('can list connection options', async() => {
-        jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' },
             { connectionType: SerialConnection, path: '/dev/test2' },
         ])
-        jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         const options = await LoupedeckCT.list()
-        expect(options.length).toBe(3)
+        assert.equal(options.length, 3)
     })
     it('can filter connection options', async() => {
-        jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' },
             { connectionType: SerialConnection, path: '/dev/test2' },
         ])
-        jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         const options = await LoupedeckCT.list({ ignoreWebsocket: true })
-        expect(options.length).toBe(2)
+        assert.equal(options.length, 2)
         const options2 = await LoupedeckCT.list({ ignoreSerial: true })
-        expect(options2.length).toBe(1)
+        assert.equal(options2.length, 1)
     })
     it('returns same connection if multiple connects are attempted', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' }
         ])
         let slowSerialConnection
-        const serialConnect = jest.spyOn(SerialConnection.prototype, 'connect').mockImplementation(function() {
+        const serialConnect = mock.method(SerialConnection.prototype, 'connect', function() {
             slowSerialConnection = this
         })
         device = new LoupedeckCT({ autoConnect: false })
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('connect', fn)
         // Try initial connect
         const connect1 = device.connect()
         await delay(40)
-        expect(fn).not.toHaveBeenCalled()
+        assert.equal(fn.mock.calls.length, 0)
 
         // Try another connect
         const connect2 = device.connect()
@@ -548,11 +566,11 @@ describe('Connection Management', () => {
         slowSerialConnection.emit('connect', { address: slowSerialConnection.path })
 
         // Both promises should resolve
-        await expect(connect1).resolves.toBe(undefined)
-        await expect(connect2).resolves.toBe(undefined)
+        assert.equal(await connect1, undefined)
+        assert.equal(await connect2, undefined)
 
-        serialDiscovery.mockRestore()
-        serialConnect.mockRestore()
+        serialDiscovery.mock.restore()
+        serialConnect.mock.restore()
         device.close()
     })
 })
@@ -565,6 +583,6 @@ describe('Edge Cases', () => {
     it('prevents transaction IDs of zero', () => {
         device.transactionID = 0xff
         device.send(0xffff, Buffer.alloc(0))
-        expect(device.transactionID).not.toBe(0)
+        assert(device.transactionID !== 0)
     })
 })

--- a/test/device-ct.test.js
+++ b/test/device-ct.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { beforeEach, describe, it, mock } from 'node:test'
+import { assertIsPixelBuffer, delay } from './helpers.js'
 
 import { MockSocket } from '../__mocks__/ws.js'
 import { MockSerialPort } from '../__mocks__/serialport.js'
@@ -10,19 +11,6 @@ mock.module('serialport', {
 const SerialConnection = (await import('../connections/serial.js')).default
 const WSConnection = (await import('../connections/ws.js')).default
 const { LoupedeckCT } = await import('../index.js')
-
-function assertIsPixelBuffer(received, { displayID, x, y, width, height }) {
-    assert(received.readUInt16BE(0) === 0xff10, `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}`)
-    assert(received.readUInt16BE(3) === displayID, `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}`)
-    assert(received.readUInt16BE(5) === x, `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}`)
-    assert(received.readUInt16BE(7) === y, `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}`)
-    assert(received.readUInt16BE(9) === width, `Width should be ${width}, but found ${received.readUInt16BE(9)}`)
-    assert(received.readUInt16BE(11) === height, `Height should be ${height}, but found ${received.readUInt16BE(11)}`)
-    const correctLength = 13 + width * height * 2
-    assert(received.length === correctLength, `Buffer length should be ${correctLength}, but found ${received.length}`)
-}
-
-const delay = ms => new Promise(res => setTimeout(res, ms))
 
 let device
 

--- a/test/device-ct.test.js
+++ b/test/device-ct.test.js
@@ -166,10 +166,6 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
-    // TODO: mock canvas
-    // it('informs the user if the canvas library is not installed', () => {
-    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
-    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-ct.test.js
+++ b/test/device-ct.test.js
@@ -166,6 +166,10 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
+    // TODO: mock canvas
+    // it('informs the user if the canvas library is not installed', () => {
+    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-live-s.test.js
+++ b/test/device-live-s.test.js
@@ -195,9 +195,15 @@ describe('Message Parsing', () => {
         const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0],
-            { x: 115, y: 226 }
-        )
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 19,
+            target: {
+                key: 11,
+                screen: 'center',
+            },
+            x: 115,
+            y: 226,
+        })
     })
     it('processes ticks', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000f9', 'hex')
@@ -210,16 +216,27 @@ describe('Message Parsing', () => {
         device.on('touchmove', fn)
         device.onReceive(SAMPLE_MESSAGE)
         device.onReceive(FOLLOW_MESSAGE)
-        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0],
-            { x: 112, y: 229 }
-        )
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 21,
+            target: {
+                screen: 'center',
+                key: 11,
+            },
+            x: 112,
+            y: 229,
+        })
     })
     it('processes screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('096d000001bf004c12', 'hex')
         const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 18,
+            target: {
+                key: 4,
+                screen: 'center'
+            },
             x: 447,
             y: 76,
         })

--- a/test/device-live-s.test.js
+++ b/test/device-live-s.test.js
@@ -124,6 +124,11 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
+    // TODO: mock canvas lib
+    // it('informs the user if the canvas library is not installed', () => {
+    //     jest.mock('canvas', () => {})
+    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-live-s.test.js
+++ b/test/device-live-s.test.js
@@ -124,11 +124,6 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
-    // TODO: mock canvas lib
-    // it('informs the user if the canvas library is not installed', () => {
-    //     jest.mock('canvas', () => {})
-    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
-    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-live-s.test.js
+++ b/test/device-live-s.test.js
@@ -31,14 +31,14 @@ describe('Commands', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('retrieves device information', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030301', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex'))
         await delay(20)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030702', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c0702000103323230000000', 'hex'))
-        await expect(promise).resolves.toEqual({
+        await assert.equal(promise, {
             version: '0.1.3',
             serial: 'LDL1101013000396700138A0001'
         })
@@ -46,33 +46,33 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await expect(promise).rejects.toThrow(/not connected/i)
+        await assert.equal(promise).rejects.toThrow(/not connected/i)
     })
     it('sets brightness', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('04090100', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0409020a', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('sets button color', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setButtonColor({ id: 4, color: 'red' })
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0702010bff0000', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0702010bff0000', 'hex'))
     })
     it('errors on unknown button passed', () => {
-        expect(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
+        assert.equal(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
     })
     it('vibrates short by default', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0101', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0101', 'hex'))
     })
     it('vibrates a specific pattern', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate(0x56)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0156', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0156', 'hex'))
     })
 })
 describe('Drawing (Callback API)', () => {
@@ -81,10 +81,10 @@ describe('Drawing (Callback API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('should report an error if attempting to write to a different display', () => {
-        expect(() => device.drawScreen('left', () => {})).toThrow(/display 'left' is not available on this device/i)
+        assert.equal(() => device.drawScreen('left', () => {})).toThrow(/display 'left' is not available on this device/i)
     })
     it('writes pixels to display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('center', (ctx, w, h) => {
             ctx.fillStyle = '#00f' // blue
             ctx.fillRect(0, 0, w, h)
@@ -92,37 +92,37 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(480 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('04d001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawKey(6, (ctx, w, h) => {
             ctx.fillStyle = '#fff'
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 90 + 15, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 90 + 15, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('04d001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('refuses to write to keys that do not exist', () => {
-        expect(() => device.drawKey(15, () => {})).toThrow(/key 15 is not a valid key/i)
+        assert.equal(() => device.drawKey(15, () => {})).toThrow(/key 15 is not a valid key/i)
     })
     it('writes pixels without refreshing the screen', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawCanvas({ id: 'center', width: 10, height: 10, autoRefresh: false }, () => {})
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenCalledTimes(1)
+        assert.equal(sender.mock.calls.length, 1)
     })
 })
 describe('Drawing (Buffer API)', () => {
@@ -132,40 +132,40 @@ describe('Drawing (Buffer API)', () => {
     })
     it('should report an error if attempting to write to a different display', async() => {
         const buffer = Buffer.from([])
-        await expect(device.drawScreen('left', buffer)).rejects.toThrow(/display 'left' is not available on this device/i)
+        await assert.equal(device.drawScreen('left', buffer)).rejects.toThrow(/display 'left' is not available on this device/i)
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(480 * 270).fill([0x1f, 0x00])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('center', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(480 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('04d001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(90 * 90 * 2).fill(0xff)
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 105, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 105, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('04d001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await expect(device.drawScreen('center', buffer)).rejects.toThrow(/expected buffer length of 259200, got 30/i)
+        await assert.equal(device.drawScreen('center', buffer)).rejects.toThrow(/expected buffer length of 259200, got 30/i)
     })
 })
 
@@ -175,86 +175,86 @@ describe('Message Parsing', () => {
     })
     it('processes button presses', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000900', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('down', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 2 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 2 })
     })
     it('processes button releases', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000701', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 0 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 0 })
     })
     it('processes clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('0501000101', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 'knobTL', delta: 1 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 'knobTL', delta: 1 })
     })
     it('processes counter-clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('05010005ff', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 'knobCR', delta: -1 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 'knobCR', delta: -1 })
     })
     it('processes initial screen touches', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e213', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 115, y: 226 })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ x: 115, y: 226 })],
         }))
     })
     it('processes ticks', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000f9', 'hex')
-        expect(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.equal(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
     })
     it('processes touch moves', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e215', 'hex')
         const FOLLOW_MESSAGE = Buffer.from('094d0000007000e515', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchmove', fn)
         device.onReceive(SAMPLE_MESSAGE)
         device.onReceive(FOLLOW_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 112, y: 229 })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ x: 112, y: 229 })],
         }))
     })
     it('processes screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('096d000001bf004c12', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({
+        assert.equal(fn.mock.calls[0].arguments[0], {
             touches: [],
-            changedTouches: [expect.objectContaining({ x: 447, y: 76 })],
+            changedTouches: [{ x: 447, y: 76 })],
         })
     })
     it('processes screen and key targets from touch events', () => {
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(Buffer.from('094d00000022008f13', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 5 } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'center', key: 5 } })],
         }))
         device.onReceive(Buffer.from('094d00000067004816', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 0 } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'center', key: 0 } })],
         }))
         device.onReceive(Buffer.from('094d000000c8008011', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 5 } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'center', key: 5 } })],
         }))
     })
     it('processes multiple simultaneous touches', () => {
-        const touchstart = jest.fn()
-        const touchmove = jest.fn()
-        const touchend = jest.fn()
+        const touchstart = mock.fn()
+        const touchmove = mock.fn()
+        const touchend = mock.fn()
         device.on('touchstart', touchstart)
         device.on('touchmove', touchmove)
         device.on('touchend', touchend)
@@ -263,168 +263,168 @@ describe('Message Parsing', () => {
         const TOUCH_1_START = Buffer.from('094d000001bf004c01', 'hex')
         const TOUCH_2_START = Buffer.from('094d00000002000102', 'hex')
         device.onReceive(TOUCH_1_START)
-        expect(touchstart).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
+        assert.equal(touchstart.calls[0].arguments[0], {
+            touches: [{ id: 1 })],
+            changedTouches: [{ id: 1 })],
         })
         device.onReceive(TOUCH_2_START)
-        expect(touchstart).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 2 })],
+        assert.equal(touchstart.calls[0].arguments[0], {
+            touches: [{ id: 1 }), { id: 2 })],
+            changedTouches: [{ id: 2 })],
         })
 
         // Independent moves
         const TOUCH_1_MOVE = Buffer.from('094d000001bf004f01', 'hex')
         const TOUCH_2_MOVE = Buffer.from('094d00000004000802', 'hex')
         device.onReceive(TOUCH_2_MOVE)
-        expect(touchmove).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 2 })],
+        assert.equal(touchmove.calls[0].arguments[0], {
+            touches: [{ id: 1 }), { id: 2 })],
+            changedTouches: [{ id: 2 })],
         })
         device.onReceive(TOUCH_1_MOVE)
-        expect(touchmove).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
+        assert.equal(touchmove.calls[0].arguments[0], {
+            touches: [{ id: 1 }), { id: 2 })],
+            changedTouches: [{ id: 1 })],
         })
 
         // Remove one touch
         const TOUCH_1_REMOVE = Buffer.from('096d000001bf004f01', 'hex')
         device.onReceive(TOUCH_1_REMOVE)
-        expect(touchend).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
+        assert.equal(touchend.calls[0].arguments[0], {
+            touches: [{ id: 2 })],
+            changedTouches: [{ id: 1 })],
         })
     })
     it('processes version information', () => {
         const VERSION_PACKET = Buffer.from('0c070201052000ff00000000', 'hex')
-        expect(device.onReceive(VERSION_PACKET)).toEqual('1.5.32')
+        assert.equal(device.onReceive(VERSION_PACKET), '1.5.32')
     })
     it('processes serial information', () => {
         const SERIAL_PACKET = Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex')
-        expect(device.onReceive(SERIAL_PACKET)).toEqual('LDL1101013000396700138A0001')
+        assert.equal(device.onReceive(SERIAL_PACKET), 'LDL1101013000396700138A0001')
     })
     it('ignores unknown messages', () => {
         const SAMPLE_MESSAGE = Buffer.from('ffffffffffffff', 'hex')
-        expect(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.equal(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
     })
 })
 
 describe('Connection Management', () => {
     it('connects to serial first if both connection types are available', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' }
         ])
-        const serialConnect = jest.spyOn(SerialConnection.prototype, 'connect').mockImplementation(function() {
+        const serialConnect = mock.method(SerialConnection.prototype, 'connect', function() {
             this.emit('connect', { address: this.path })
         })
-        const wsDiscovery = jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        const wsDiscovery = mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         device = new LoupedeckLiveS()
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('connect', fn)
         await device.connect()
-        expect(fn).toHaveBeenCalledWith({ address: '/dev/test1' })
-        serialDiscovery.mockRestore()
-        serialConnect.mockRestore()
-        wsDiscovery.mockRestore()
+        assert.equal(fn.mock.calls[0].arguments[0], { address: '/dev/test1' })
+        serialDiscovery.mock.restore()
+        serialConnect.mock.restore()
+        wsDiscovery.mock.restore()
         device.close()
     })
     it('connects to serial if path explicitly set', () => {
         device = new LoupedeckLiveS({ path: '/dev/test2' })
-        expect(device.connection).toBeInstanceOf(SerialConnection)
+        assert(device.connection instanceof SerialConnection)
         device.close()
     })
     it('connects to websocket if host explicitly set', () => {
         device = new LoupedeckLiveS({ host: '255.255.255.255' })
-        expect(device.connection).toBeInstanceOf(WSConnection)
+        assert(device.connection instanceof WSConnection)
         device.close()
     })
     it('attempts reconnect if device not found', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [])
-        const wsDiscovery = jest.spyOn(WSConnection, 'discover').mockImplementation(() => [])
-        const fn = jest.fn()
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [])
+        const wsDiscovery = mock.method(WSConnection, 'discover', () => [])
+        const fn = mock.fn()
         device = new LoupedeckLiveS({ autoConnect: false, reconnectInterval: 20 })
         device.on('disconnect', fn)
-        const connect = jest.spyOn(device, 'connect')
-        await expect(device.connect()).rejects.toMatch(/no devices found/i)
+        const connect = mock.method(device, 'connect')
+        await assert.equal(device.connect()).rejects.toMatch(/no devices found/i)
         await delay(40)
-        expect(connect.mock.calls.length).toBeGreaterThanOrEqual(2)
-        expect(fn.mock.calls[0][0].message).toMatch(/no devices found/i)
-        serialDiscovery.mockRestore()
-        wsDiscovery.mockRestore()
+        assert.equal(connect.mock.calls.length).toBeGreaterThanOrEqual(2)
+        assert.equal(fn.mock.calls[0][0].message).toMatch(/no devices found/i)
+        serialDiscovery.mock.restore()
+        wsDiscovery.mock.restore()
         device.close()
     })
     it('attempts reconnect on error', async() => {
         device = new LoupedeckLiveS({ autoConnect: false, reconnectInterval: 20 })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => Promise.reject('some error'))
+        const connect = mock.method(device, 'connect', () => Promise.reject('some error'))
         device.onDisconnect('some error')
         await delay(40)
-        expect(connect).toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
         device.close()
     })
     it('does not attempt reconnect if closed before reconnect time', async() => {
         device = new LoupedeckLiveS({ autoConnect: false, reconnectInterval: 20 })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => {})
+        const connect = mock.method(device, 'connect', () => {})
         device.onDisconnect('some error')
         device.onDisconnect()
         await delay(40)
-        expect(connect).not.toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
     })
     it('does not attempt reconnect if reconnect interval not set', async() => {
         device = new LoupedeckLiveS({ autoConnect: false, reconnectInterval: false })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => {})
+        const connect = mock.method(device, 'connect', () => {})
         device.onDisconnect('some error')
         await delay(100)
-        expect(connect).not.toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
     })
     it('ignores commands if connection not open', () => {
         device = new LoupedeckLiveS({ path: '/dev/test3', autoConnect: false })
         device.connection = { send: () => {}, isReady: () => false, close: () => {} }
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.send('test', Buffer.from([0xff]))
-        expect(sender).not.toHaveBeenCalled()
+        assert.equal(sender.mock.calls.length, 0)
         device.close()
     })
     it('can list connection options', async() => {
-        jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' },
             { connectionType: SerialConnection, path: '/dev/test2' },
         ])
-        jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         const options = await LoupedeckLiveS.list()
-        expect(options.length).toBe(3)
+        assert.equal(options.length, 3)
     })
     it('can filter connection options', async() => {
-        jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' },
             { connectionType: SerialConnection, path: '/dev/test2' },
         ])
-        jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         const options = await LoupedeckLiveS.list({ ignoreWebsocket: true })
-        expect(options.length).toBe(2)
+        assert.equal(options.length, 2)
         const options2 = await LoupedeckLiveS.list({ ignoreSerial: true })
-        expect(options2.length).toBe(1)
+        assert.equal(options2.length, 1)
     })
     it('returns same connection if multiple connects are attempted', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' }
         ])
         let slowSerialConnection
-        const serialConnect = jest.spyOn(SerialConnection.prototype, 'connect').mockImplementation(function() {
+        const serialConnect = mock.method(SerialConnection.prototype, 'connect', function() {
             slowSerialConnection = this
         })
         device = new LoupedeckLiveS({ autoConnect: false })
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('connect', fn)
         // Try initial connect
         const connect1 = device.connect()
         await delay(40)
-        expect(fn).not.toHaveBeenCalled()
+        assert.equal(fn.mock.calls.length, 0)
 
         // Try another connect
         const connect2 = device.connect()
@@ -433,11 +433,11 @@ describe('Connection Management', () => {
         slowSerialConnection.emit('connect', { address: slowSerialConnection.path })
 
         // Both promises should resolve
-        await expect(connect1).resolves.toBe(undefined)
-        await expect(connect2).resolves.toBe(undefined)
+        await assert.equal(connect1, undefined)
+        await assert.equal(connect2, undefined)
 
-        serialDiscovery.mockRestore()
-        serialConnect.mockRestore()
+        serialDiscovery.mock.restore()
+        serialConnect.mock.restore()
         device.close()
     })
 })
@@ -450,6 +450,6 @@ describe('Edge Cases', () => {
     it('prevents transaction IDs of zero', () => {
         device.transactionID = 0xff
         device.send(0xffff, Buffer.alloc(0))
-        expect(device.transactionID).not.toBe(0)
+        assert.equal(device.transactionID).not.toBe(0)
     })
 })

--- a/test/device-live.test.js
+++ b/test/device-live.test.js
@@ -150,11 +150,6 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
-    // TODO: Mock canvas lib
-    // it('informs the user if the canvas library is not installed', () => {
-    //     jest.mock('canvas', () => {})
-    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
-    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-live.test.js
+++ b/test/device-live.test.js
@@ -150,6 +150,11 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
+    // TODO: Mock canvas lib
+    // it('informs the user if the canvas library is not installed', () => {
+    //     jest.mock('canvas', () => {})
+    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-live.test.js
+++ b/test/device-live.test.js
@@ -1,27 +1,17 @@
-import { jest } from '@jest/globals'
-import * as mockWS from '../__mocks__/ws.js'
-import * as serialport from '../__mocks__/serialport.js'
-jest.unstable_mockModule('ws', () => mockWS)
-jest.unstable_mockModule('serialport', () => serialport)
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it, mock } from 'node:test'
+import { assertIsPixelBuffer, delay } from './helpers.js'
+
+import { MockSocket } from '../__mocks__/ws.js'
+import { MockSerialPort } from '../__mocks__/serialport.js'
+mock.module('ws', { defaultExport: MockSocket })
+mock.module('serialport', {
+    namedExports: { SerialPort: MockSerialPort }
+})
+
 const SerialConnection = (await import('../connections/serial.js')).default
 const WSConnection = (await import('../connections/ws.js')).default
 const { LoupedeckLive } = await import('../index.js')
-
-expect.extend({
-    toBePixelBuffer(received, { displayID, x, y, width, height }) {
-        if (received.readUInt16BE(0) !== 0xff10) return { pass: false, message: () => `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}` }
-        if (received.readUInt16BE(3) !== displayID) return { pass: false, message: () => `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}` }
-        if (received.readUInt16BE(5) !== x) return { pass: false, message: () => `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}` }
-        if (received.readUInt16BE(7) !== y) return { pass: false, message: () => `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}` }
-        if (received.readUInt16BE(9) !== width) return { pass: false, message: () => `Width should be ${width}, but found ${received.readUInt16BE(9)}` }
-        if (received.readUInt16BE(11) !== height) return { pass: false, message: () => `Height should be ${height}, but found ${received.readUInt16BE(11)}` }
-        const correctLength = 13 + width * height * 2
-        if (received.length !== correctLength) return { pass: false, message: () => `Buffer length should be ${correctLength}, but found ${received.length}` }
-        return { pass: true }
-    }
-})
-
-const delay = ms => new Promise(res => setTimeout(res, ms))
 
 let device
 
@@ -33,12 +23,12 @@ describe('Commands', () => {
     it('retrieves device information', async() => {
         const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex'))
         await delay(20)
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030702', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c070201052000ff00000000', 'hex'))
-        await assert.equal(promise, {
+        assert.deepEqual(await promise, {
             version: '1.5.32',
             serial: 'LDL1101013000396700138A0001'
         })
@@ -46,33 +36,33 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await assert.equal(promise).rejects.toThrow(/not connected/i)
+        await assert.rejects(promise, /not connected/i)
     })
     it('sets brightness', () => {
         const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0409020a', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('sets button color', () => {
         const sender = mock.method(device.connection, 'send')
         device.setButtonColor({ id: 4, color: 'red' })
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0702010bff0000', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('0702010bff0000', 'hex'))
     })
     it('errors on unknown button passed', () => {
-        assert.equal(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
+        assert.throws(() => device.setButtonColor({ id: 'triangle', color: 'blue' }), /Invalid button/)
     })
     it('vibrates short by default', () => {
         const sender = mock.method(device.connection, 'send')
         device.vibrate()
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0101', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('041b0101', 'hex'))
     })
     it('vibrates a specific pattern', () => {
         const sender = mock.method(device.connection, 'send')
         device.vibrate(0x56)
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0156', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('041b0156', 'hex'))
     })
 })
 describe('Drawing (Callback API)', () => {
@@ -89,12 +79,12 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so first 5 bits for full red is 0xf800, or 0x00f8 in LE
         const pixels = '00f8'.repeat(60 * 270)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to right display', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -105,12 +95,12 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const pixels = 'e007'.repeat(60 * 270)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to center display', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -121,12 +111,12 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(360 * 270)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -135,12 +125,12 @@ describe('Drawing (Callback API)', () => {
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(90 * 90)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels without refreshing the screen', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -162,12 +152,12 @@ describe('Drawing (Buffer API)', () => {
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('left', buffer)
         const hex = '00f8'.repeat(60 * 270)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to right display', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -177,12 +167,12 @@ describe('Drawing (Buffer API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const hex = 'e007'.repeat(60 * 270)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to center display', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -192,12 +182,12 @@ describe('Drawing (Buffer API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(360 * 270)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -205,17 +195,17 @@ describe('Drawing (Buffer API)', () => {
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(90 * 90)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await assert.equal(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
+        await assert.rejects(device.drawScreen('left', buffer), /expected buffer length of 32400, got 30/i)
     })
 })
 
@@ -228,48 +218,46 @@ describe('Message Parsing', () => {
         const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls.length, 0)
+        assert.deepEqual(fn.mock.calls.length, 0)
     })
     it('processes button presses', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000900', 'hex')
         const fn = mock.fn()
         device.on('down', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], { id: 2 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 2 })
     })
     it('processes button releases', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000701', 'hex')
         const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], { id: 0 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 0 })
     })
     it('processes clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('0501000101', 'hex')
         const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], { id: 'knobTL', delta: 1 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 'knobTL', delta: 1 })
     })
     it('processes counter-clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('05010005ff', 'hex')
         const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], { id: 'knobCR', delta: -1 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { id: 'knobCR', delta: -1 })
     })
     it('processes initial screen touches', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e213', 'hex')
         const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ x: 115, y: 226 })],
-        }))
+        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], { x: 115, y: 226 })
     })
     it('processes ticks', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000f9', 'hex')
-        assert.equal(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.doesNotThrow(() => device.onReceive(SAMPLE_MESSAGE))
     })
     it('processes touch moves', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e215', 'hex')
@@ -278,43 +266,31 @@ describe('Message Parsing', () => {
         device.on('touchmove', fn)
         device.onReceive(SAMPLE_MESSAGE)
         device.onReceive(FOLLOW_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ x: 112, y: 229 })],
-        }))
+        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], { x: 112, y: 229 })
     })
     it('processes screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('096d000001bf004c12', 'hex')
         const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            touches: [],
-            changedTouches: [{ x: 447, y: 76 })],
+        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            x: 447,
+            y: 76,
         })
     })
     it('processes screen and key targets from touch events', () => {
         const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(Buffer.from('094d00000022008f13', 'hex'))
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ target: { screen: 'left', key: undefined } })],
-        }))
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0].target, { screen: 'left' })
         device.onReceive(Buffer.from('094d00000067004816', 'hex'))
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ target: { screen: 'center', key: 0 } })],
-        }))
+        assert.deepEqual(fn.mock.calls[1].arguments[0].changedTouches[0].target, { screen: 'center', key: 0 })
         device.onReceive(Buffer.from('094d000000c8008011', 'hex'))
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ target: { screen: 'center', key: 5 } })],
-        }))
+        assert.deepEqual(fn.mock.calls[2].arguments[0].changedTouches[0].target, { screen: 'center', key: 5 })
         device.onReceive(Buffer.from('094d0000017500d21a', 'hex'))
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ target: { screen: 'center', key: 11 } })],
-        }))
+        assert.deepEqual(fn.mock.calls[3].arguments[0].changedTouches[0].target, { screen: 'center', key: 11 })
         device.onReceive(Buffer.from('094d000001c200b8ff', 'hex'))
-        assert.equal(fn.mock.calls[0].arguments[0], {
-            changedTouches: [{ target: { screen: 'right', key: undefined } })],
-        }))
+        assert.deepEqual(fn.mock.calls[4].arguments[0].changedTouches[0].target, { screen: 'right' })
     })
     it('processes multiple simultaneous touches', () => {
         const touchstart = mock.fn()
@@ -323,42 +299,40 @@ describe('Message Parsing', () => {
         device.on('touchstart', touchstart)
         device.on('touchmove', touchmove)
         device.on('touchend', touchend)
+        let ev
 
         // Multiple starts
         const TOUCH_1_START = Buffer.from('094d000001bf004c01', 'hex')
         const TOUCH_2_START = Buffer.from('094d00000002000102', 'hex')
         device.onReceive(TOUCH_1_START)
-        assert.equal(touchstart.calls[0].arguments[0], {
-            touches: [{ id: 1 })],
-            changedTouches: [{ id: 1 })],
-        })
+        ev = touchstart.mock.calls[0].arguments[0]
+        assert.equal(ev.touches.length, 1)
+        assert.equal(ev.changedTouches[0].id, 1)
+
         device.onReceive(TOUCH_2_START)
-        assert.equal(touchstart.calls[0].arguments[0], {
-            touches: [{ id: 1 }), { id: 2 })],
-            changedTouches: [{ id: 2 })],
-        })
+        ev = touchstart.mock.calls[1].arguments[0]
+        assert.equal(ev.touches.length, 2)
+        assert.equal(ev.changedTouches[0].id, 2)
 
         // Independent moves
         const TOUCH_1_MOVE = Buffer.from('094d000001bf004f01', 'hex')
         const TOUCH_2_MOVE = Buffer.from('094d00000004000802', 'hex')
         device.onReceive(TOUCH_2_MOVE)
-        assert.equal(touchmove.calls[0].arguments[0], {
-            touches: [{ id: 1 }), { id: 2 })],
-            changedTouches: [{ id: 2 })],
-        })
+        ev = touchmove.mock.calls[0].arguments[0]
+        assert.equal(ev.touches.length, 2)
+        assert.equal(ev.changedTouches[0].id, 2)
+
         device.onReceive(TOUCH_1_MOVE)
-        assert.equal(touchmove.calls[0].arguments[0], {
-            touches: [{ id: 1 }), { id: 2 })],
-            changedTouches: [{ id: 1 })],
-        })
+        ev = touchmove.mock.calls[1].arguments[0]
+        assert.equal(ev.touches.length, 2)
+        assert.equal(ev.changedTouches[0].id, 1)
 
         // Remove one touch
         const TOUCH_1_REMOVE = Buffer.from('096d000001bf004f01', 'hex')
         device.onReceive(TOUCH_1_REMOVE)
-        assert.equal(touchend.calls[0].arguments[0], {
-            touches: [{ id: 2 })],
-            changedTouches: [{ id: 1 })],
-        })
+        ev = touchend.mock.calls[0].arguments[0]
+        assert.equal(ev.touches.length, 1)
+        assert.equal(ev.changedTouches[0].id, 1)
     })
     it('processes version information', () => {
         const VERSION_PACKET = Buffer.from('0c070201052000ff00000000', 'hex')
@@ -370,7 +344,7 @@ describe('Message Parsing', () => {
     })
     it('ignores unknown messages', () => {
         const SAMPLE_MESSAGE = Buffer.from('ffffffffffffff', 'hex')
-        assert.equal(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.doesNotThrow(() => device.onReceive(SAMPLE_MESSAGE))
     })
 })
 
@@ -389,7 +363,7 @@ describe('Connection Management', () => {
         const fn = mock.fn()
         device.on('connect', fn)
         await device.connect()
-        assert.equal(fn.mock.calls[0].arguments[0], { address: '/dev/test1' })
+        assert.deepEqual(fn.mock.calls[0].arguments[0], { address: '/dev/test1' })
         serialDiscovery.mock.restore()
         serialConnect.mock.restore()
         wsDiscovery.mock.restore()
@@ -412,10 +386,10 @@ describe('Connection Management', () => {
         device = new LoupedeckLive({ autoConnect: false, reconnectInterval: 20 })
         device.on('disconnect', fn)
         const connect = mock.method(device, 'connect')
-        await assert.equal(device.connect()).rejects.toMatch(/no devices found/i)
+        await assert.rejects(device.connect(), /no devices found/i)
         await delay(40)
-        assert.equal(connect.mock.calls.length).toBeGreaterThanOrEqual(2)
-        assert.equal(fn.mock.calls[0][0].message).toMatch(/no devices found/i)
+        assert(connect.mock.calls.length >= 2)
+        assert.match(fn.mock.calls[0].arguments[0].message, /no devices found/i)
         serialDiscovery.mock.restore()
         wsDiscovery.mock.restore()
         device.close()
@@ -425,7 +399,7 @@ describe('Connection Management', () => {
         const connect = mock.method(device, 'connect', () => Promise.reject('some error'))
         device.onDisconnect('some error')
         await delay(40)
-        assert.equal(connect.mock.calls.length, 0)
+        assert(connect.mock.calls.length > 0)
         device.close()
     })
     it('does not attempt reconnect if closed before reconnect time', async() => {
@@ -498,8 +472,8 @@ describe('Connection Management', () => {
         slowSerialConnection.emit('connect', { address: slowSerialConnection.path })
 
         // Both promises should resolve
-        await assert.equal(connect1, undefined)
-        await assert.equal(connect2, undefined)
+        assert.equal(await connect1, undefined)
+        assert.equal(await connect2, undefined)
 
         serialDiscovery.mock.restore()
         serialConnect.mock.restore()
@@ -515,6 +489,6 @@ describe('Edge Cases', () => {
     it('prevents transaction IDs of zero', () => {
         device.transactionID = 0xff
         device.send(0xffff, Buffer.alloc(0))
-        assert.equal(device.transactionID).not.toBe(0)
+        assert(device.transactionID !== 0)
     })
 })

--- a/test/device-live.test.js
+++ b/test/device-live.test.js
@@ -253,7 +253,15 @@ describe('Message Parsing', () => {
         const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], { x: 115, y: 226 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 19,
+            target: {
+                screen: 'center',
+                key: 8,
+            },
+            x: 115,
+            y: 226,
+        })
     })
     it('processes ticks', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000f9', 'hex')
@@ -266,14 +274,26 @@ describe('Message Parsing', () => {
         device.on('touchmove', fn)
         device.onReceive(SAMPLE_MESSAGE)
         device.onReceive(FOLLOW_MESSAGE)
-        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], { x: 112, y: 229 })
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 21,
+            target: {
+                screen: 'center',
+                key: 8,
+            },
+            x: 112,
+            y: 229,
+        })
     })
     it('processes screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('096d000001bf004c12', 'hex')
         const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        assert.partialDeepStrictEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+        assert.deepEqual(fn.mock.calls[0].arguments[0].changedTouches[0], {
+            id: 18,
+            target: {
+                screen: 'right'
+            },
             x: 447,
             y: 76,
         })

--- a/test/device-live.test.js
+++ b/test/device-live.test.js
@@ -31,14 +31,14 @@ describe('Commands', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('retrieves device information', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030301', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex'))
         await delay(20)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030702', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c070201052000ff00000000', 'hex'))
-        await expect(promise).resolves.toEqual({
+        await assert.equal(promise, {
             version: '1.5.32',
             serial: 'LDL1101013000396700138A0001'
         })
@@ -46,33 +46,33 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await expect(promise).rejects.toThrow(/not connected/i)
+        await assert.equal(promise).rejects.toThrow(/not connected/i)
     })
     it('sets brightness', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('04090100', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0409020a', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('sets button color', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setButtonColor({ id: 4, color: 'red' })
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0702010bff0000', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0702010bff0000', 'hex'))
     })
     it('errors on unknown button passed', () => {
-        expect(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
+        assert.equal(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
     })
     it('vibrates short by default', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0101', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0101', 'hex'))
     })
     it('vibrates a specific pattern', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate(0x56)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0156', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0156', 'hex'))
     })
 })
 describe('Drawing (Callback API)', () => {
@@ -81,7 +81,7 @@ describe('Drawing (Callback API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to left display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('left', (ctx, w, h) => {
             ctx.fillStyle = '#f00' // red
             ctx.fillRect(0, 0, w, h)
@@ -89,15 +89,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so first 5 bits for full red is 0xf800, or 0x00f8 in LE
         const pixels = '00f8'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to right display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('right', (ctx, w, h) => {
             ctx.fillStyle = '#0f0' // green
             ctx.fillRect(0, 0, w, h)
@@ -105,15 +105,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const pixels = 'e007'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('center', (ctx, w, h) => {
             ctx.fillStyle = '#00f' // blue
             ctx.fillRect(0, 0, w, h)
@@ -121,34 +121,34 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(360 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawKey(6, (ctx, w, h) => {
             ctx.fillStyle = '#fff'
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels without refreshing the screen', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawCanvas({ id: 'center', width: 10, height: 10, autoRefresh: false }, () => {})
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenCalledTimes(1)
+        assert.equal(sender.mock.calls.length, 1)
     })
 })
 describe('Drawing (Buffer API)', () => {
@@ -157,65 +157,65 @@ describe('Drawing (Buffer API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to left display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(60 * 270).fill([0x00, 0xf8])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('left', buffer)
         const hex = '00f8'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to right display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(60 * 270).fill([0xe0, 0x07])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('right', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const hex = 'e007'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(360 * 270).fill([0x1f, 0x00])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('center', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(360 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(90 * 90 * 2).fill(0xff)
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await expect(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
+        await assert.equal(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
     })
 })
 
@@ -225,101 +225,101 @@ describe('Message Parsing', () => {
     })
     it('processes timestamp events', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000ba', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).not.toHaveBeenCalled()
+        assert.equal(fn.mock.calls.length, 0)
     })
     it('processes button presses', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000900', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('down', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 2 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 2 })
     })
     it('processes button releases', () => {
         const SAMPLE_MESSAGE = Buffer.from('0500000701', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('up', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 0 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 0 })
     })
     it('processes clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('0501000101', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 'knobTL', delta: 1 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 'knobTL', delta: 1 })
     })
     it('processes counter-clockwise knob turns', () => {
         const SAMPLE_MESSAGE = Buffer.from('05010005ff', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('rotate', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({ id: 'knobCR', delta: -1 })
+        assert.equal(fn.mock.calls[0].arguments[0], { id: 'knobCR', delta: -1 })
     })
     it('processes initial screen touches', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e213', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 115, y: 226 })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ x: 115, y: 226 })],
         }))
     })
     it('processes ticks', () => {
         const SAMPLE_MESSAGE = Buffer.from('040000f9', 'hex')
-        expect(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.equal(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
     })
     it('processes touch moves', () => {
         const SAMPLE_MESSAGE = Buffer.from('094d0000007300e215', 'hex')
         const FOLLOW_MESSAGE = Buffer.from('094d0000007000e515', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchmove', fn)
         device.onReceive(SAMPLE_MESSAGE)
         device.onReceive(FOLLOW_MESSAGE)
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ x: 112, y: 229 })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ x: 112, y: 229 })],
         }))
     })
     it('processes screen touchends', () => {
         const SAMPLE_MESSAGE = Buffer.from('096d000001bf004c12', 'hex')
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchend', fn)
         device.onReceive(SAMPLE_MESSAGE)
-        expect(fn).toHaveBeenCalledWith({
+        assert.equal(fn.mock.calls[0].arguments[0], {
             touches: [],
-            changedTouches: [expect.objectContaining({ x: 447, y: 76 })],
+            changedTouches: [{ x: 447, y: 76 })],
         })
     })
     it('processes screen and key targets from touch events', () => {
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('touchstart', fn)
         device.onReceive(Buffer.from('094d00000022008f13', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'left', key: undefined } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'left', key: undefined } })],
         }))
         device.onReceive(Buffer.from('094d00000067004816', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 0 } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'center', key: 0 } })],
         }))
         device.onReceive(Buffer.from('094d000000c8008011', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 5 } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'center', key: 5 } })],
         }))
         device.onReceive(Buffer.from('094d0000017500d21a', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'center', key: 11 } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'center', key: 11 } })],
         }))
         device.onReceive(Buffer.from('094d000001c200b8ff', 'hex'))
-        expect(fn).toHaveBeenCalledWith(expect.objectContaining({
-            changedTouches: [expect.objectContaining({ target: { screen: 'right', key: undefined } })],
+        assert.equal(fn.mock.calls[0].arguments[0], {
+            changedTouches: [{ target: { screen: 'right', key: undefined } })],
         }))
     })
     it('processes multiple simultaneous touches', () => {
-        const touchstart = jest.fn()
-        const touchmove = jest.fn()
-        const touchend = jest.fn()
+        const touchstart = mock.fn()
+        const touchmove = mock.fn()
+        const touchend = mock.fn()
         device.on('touchstart', touchstart)
         device.on('touchmove', touchmove)
         device.on('touchend', touchend)
@@ -328,168 +328,168 @@ describe('Message Parsing', () => {
         const TOUCH_1_START = Buffer.from('094d000001bf004c01', 'hex')
         const TOUCH_2_START = Buffer.from('094d00000002000102', 'hex')
         device.onReceive(TOUCH_1_START)
-        expect(touchstart).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
+        assert.equal(touchstart.calls[0].arguments[0], {
+            touches: [{ id: 1 })],
+            changedTouches: [{ id: 1 })],
         })
         device.onReceive(TOUCH_2_START)
-        expect(touchstart).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 2 })],
+        assert.equal(touchstart.calls[0].arguments[0], {
+            touches: [{ id: 1 }), { id: 2 })],
+            changedTouches: [{ id: 2 })],
         })
 
         // Independent moves
         const TOUCH_1_MOVE = Buffer.from('094d000001bf004f01', 'hex')
         const TOUCH_2_MOVE = Buffer.from('094d00000004000802', 'hex')
         device.onReceive(TOUCH_2_MOVE)
-        expect(touchmove).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 2 })],
+        assert.equal(touchmove.calls[0].arguments[0], {
+            touches: [{ id: 1 }), { id: 2 })],
+            changedTouches: [{ id: 2 })],
         })
         device.onReceive(TOUCH_1_MOVE)
-        expect(touchmove).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
+        assert.equal(touchmove.calls[0].arguments[0], {
+            touches: [{ id: 1 }), { id: 2 })],
+            changedTouches: [{ id: 1 })],
         })
 
         // Remove one touch
         const TOUCH_1_REMOVE = Buffer.from('096d000001bf004f01', 'hex')
         device.onReceive(TOUCH_1_REMOVE)
-        expect(touchend).toHaveBeenCalledWith({
-            touches: [expect.objectContaining({ id: 2 })],
-            changedTouches: [expect.objectContaining({ id: 1 })],
+        assert.equal(touchend.calls[0].arguments[0], {
+            touches: [{ id: 2 })],
+            changedTouches: [{ id: 1 })],
         })
     })
     it('processes version information', () => {
         const VERSION_PACKET = Buffer.from('0c070201052000ff00000000', 'hex')
-        expect(device.onReceive(VERSION_PACKET)).toEqual('1.5.32')
+        assert.equal(device.onReceive(VERSION_PACKET), '1.5.32')
     })
     it('processes serial information', () => {
         const SERIAL_PACKET = Buffer.from('1f03014c444c31313031303133303030333936373030313338413030303120', 'hex')
-        expect(device.onReceive(SERIAL_PACKET)).toEqual('LDL1101013000396700138A0001')
+        assert.equal(device.onReceive(SERIAL_PACKET), 'LDL1101013000396700138A0001')
     })
     it('ignores unknown messages', () => {
         const SAMPLE_MESSAGE = Buffer.from('ffffffffffffff', 'hex')
-        expect(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
+        assert.equal(() => device.onReceive(SAMPLE_MESSAGE)).not.toThrow()
     })
 })
 
 describe('Connection Management', () => {
     it('connects to serial first if both connection types are available', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' }
         ])
-        const serialConnect = jest.spyOn(SerialConnection.prototype, 'connect').mockImplementation(function() {
+        const serialConnect = mock.method(SerialConnection.prototype, 'connect', function() {
             this.emit('connect', { address: this.path })
         })
-        const wsDiscovery = jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        const wsDiscovery = mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         device = new LoupedeckLive()
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('connect', fn)
         await device.connect()
-        expect(fn).toHaveBeenCalledWith({ address: '/dev/test1' })
-        serialDiscovery.mockRestore()
-        serialConnect.mockRestore()
-        wsDiscovery.mockRestore()
+        assert.equal(fn.mock.calls[0].arguments[0], { address: '/dev/test1' })
+        serialDiscovery.mock.restore()
+        serialConnect.mock.restore()
+        wsDiscovery.mock.restore()
         device.close()
     })
     it('connects to serial if path explicitly set', () => {
         device = new LoupedeckLive({ path: '/dev/test2' })
-        expect(device.connection).toBeInstanceOf(SerialConnection)
+        assert(device.connection instanceof SerialConnection)
         device.close()
     })
     it('connects to websocket if host explicitly set', () => {
         device = new LoupedeckLive({ host: '255.255.255.255' })
-        expect(device.connection).toBeInstanceOf(WSConnection)
+        assert(device.connection instanceof WSConnection)
         device.close()
     })
     it('attempts reconnect if device not found', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [])
-        const wsDiscovery = jest.spyOn(WSConnection, 'discover').mockImplementation(() => [])
-        const fn = jest.fn()
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [])
+        const wsDiscovery = mock.method(WSConnection, 'discover', () => [])
+        const fn = mock.fn()
         device = new LoupedeckLive({ autoConnect: false, reconnectInterval: 20 })
         device.on('disconnect', fn)
-        const connect = jest.spyOn(device, 'connect')
-        await expect(device.connect()).rejects.toMatch(/no devices found/i)
+        const connect = mock.method(device, 'connect')
+        await assert.equal(device.connect()).rejects.toMatch(/no devices found/i)
         await delay(40)
-        expect(connect.mock.calls.length).toBeGreaterThanOrEqual(2)
-        expect(fn.mock.calls[0][0].message).toMatch(/no devices found/i)
-        serialDiscovery.mockRestore()
-        wsDiscovery.mockRestore()
+        assert.equal(connect.mock.calls.length).toBeGreaterThanOrEqual(2)
+        assert.equal(fn.mock.calls[0][0].message).toMatch(/no devices found/i)
+        serialDiscovery.mock.restore()
+        wsDiscovery.mock.restore()
         device.close()
     })
     it('attempts reconnect on error', async() => {
         device = new LoupedeckLive({ autoConnect: false, reconnectInterval: 20 })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => Promise.reject('some error'))
+        const connect = mock.method(device, 'connect', () => Promise.reject('some error'))
         device.onDisconnect('some error')
         await delay(40)
-        expect(connect).toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
         device.close()
     })
     it('does not attempt reconnect if closed before reconnect time', async() => {
         device = new LoupedeckLive({ autoConnect: false, reconnectInterval: 20 })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => {})
+        const connect = mock.method(device, 'connect', () => {})
         device.onDisconnect('some error')
         device.onDisconnect()
         await delay(40)
-        expect(connect).not.toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
     })
     it('does not attempt reconnect if reconnect interval not set', async() => {
         device = new LoupedeckLive({ autoConnect: false, reconnectInterval: false })
-        const connect = jest.spyOn(device, 'connect').mockImplementation(() => {})
+        const connect = mock.method(device, 'connect', () => {})
         device.onDisconnect('some error')
         await delay(100)
-        expect(connect).not.toHaveBeenCalled()
+        assert.equal(connect.mock.calls.length, 0)
     })
     it('ignores commands if connection not open', () => {
         device = new LoupedeckLive({ path: '/dev/test3', autoConnect: false })
         device.connection = { send: () => {}, isReady: () => false, close: () => {} }
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.send('test', Buffer.from([0xff]))
-        expect(sender).not.toHaveBeenCalled()
+        assert.equal(sender.mock.calls.length, 0)
         device.close()
     })
     it('can list connection options', async() => {
-        jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' },
             { connectionType: SerialConnection, path: '/dev/test2' },
         ])
-        jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         const options = await LoupedeckLive.list()
-        expect(options.length).toBe(3)
+        assert.equal(options.length, 3)
     })
     it('can filter connection options', async() => {
-        jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' },
             { connectionType: SerialConnection, path: '/dev/test2' },
         ])
-        jest.spyOn(WSConnection, 'discover').mockImplementation(() => [
+        mock.method(WSConnection, 'discover', () => [
             { connectionType: WSConnection, host: '128.0.0.1' }
         ])
         const options = await LoupedeckLive.list({ ignoreWebsocket: true })
-        expect(options.length).toBe(2)
+        assert.equal(options.length, 2)
         const options2 = await LoupedeckLive.list({ ignoreSerial: true })
-        expect(options2.length).toBe(1)
+        assert.equal(options2.length, 1)
     })
     it('returns same connection if multiple connects are attempted', async() => {
-        const serialDiscovery = jest.spyOn(SerialConnection, 'discover').mockImplementation(() => [
+        const serialDiscovery = mock.method(SerialConnection, 'discover', () => [
             { connectionType: SerialConnection, path: '/dev/test1' }
         ])
         let slowSerialConnection
-        const serialConnect = jest.spyOn(SerialConnection.prototype, 'connect').mockImplementation(function() {
+        const serialConnect = mock.method(SerialConnection.prototype, 'connect', function() {
             slowSerialConnection = this
         })
         device = new LoupedeckLive({ autoConnect: false })
-        const fn = jest.fn()
+        const fn = mock.fn()
         device.on('connect', fn)
         // Try initial connect
         const connect1 = device.connect()
         await delay(40)
-        expect(fn).not.toHaveBeenCalled()
+        assert.equal(fn.mock.calls.length, 0)
 
         // Try another connect
         const connect2 = device.connect()
@@ -498,11 +498,11 @@ describe('Connection Management', () => {
         slowSerialConnection.emit('connect', { address: slowSerialConnection.path })
 
         // Both promises should resolve
-        await expect(connect1).resolves.toBe(undefined)
-        await expect(connect2).resolves.toBe(undefined)
+        await assert.equal(connect1, undefined)
+        await assert.equal(connect2, undefined)
 
-        serialDiscovery.mockRestore()
-        serialConnect.mockRestore()
+        serialDiscovery.mock.restore()
+        serialConnect.mock.restore()
         device.close()
     })
 })
@@ -515,6 +515,6 @@ describe('Edge Cases', () => {
     it('prevents transaction IDs of zero', () => {
         device.transactionID = 0xff
         device.send(0xffff, Buffer.alloc(0))
-        expect(device.transactionID).not.toBe(0)
+        assert.equal(device.transactionID).not.toBe(0)
     })
 })

--- a/test/device-razer-x.test.js
+++ b/test/device-razer-x.test.js
@@ -1,21 +1,14 @@
-import { jest } from '@jest/globals'
-import { RazerStreamControllerX } from '../index.js'
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it, mock } from 'node:test'
+import { assertIsPixelBuffer, delay } from './helpers.js'
 
-expect.extend({
-    toBePixelBuffer(received, { displayID, x, y, width, height }) {
-        if (received.readUInt16BE(0) !== 0xff10) return { pass: false, message: () => `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}` }
-        if (received.readUInt16BE(3) !== displayID) return { pass: false, message: () => `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}` }
-        if (received.readUInt16BE(5) !== x) return { pass: false, message: () => `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}` }
-        if (received.readUInt16BE(7) !== y) return { pass: false, message: () => `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}` }
-        if (received.readUInt16BE(9) !== width) return { pass: false, message: () => `Width should be ${width}, but found ${received.readUInt16BE(9)}` }
-        if (received.readUInt16BE(11) !== height) return { pass: false, message: () => `Height should be ${height}, but found ${received.readUInt16BE(11)}` }
-        const correctLength = 13 + width * height * 2
-        if (received.length !== correctLength) return { pass: false, message: () => `Buffer length should be ${correctLength}, but found ${received.length}` }
-        return { pass: true }
-    }
+import { MockSocket } from '../__mocks__/ws.js'
+import { MockSerialPort } from '../__mocks__/serialport.js'
+mock.module('ws', { defaultExport: MockSocket })
+mock.module('serialport', {
+    namedExports: { SerialPort: MockSerialPort }
 })
-
-const delay = ms => new Promise(res => setTimeout(res, ms))
+import { RazerStreamControllerX } from '../index.js'
 
 let device
 
@@ -27,12 +20,12 @@ describe('Commands', () => {
     it('retrieves device information', async() => {
         const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f03015055323532344c303637303032313020202020202020202020202020', 'hex'))
         await delay(20)
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030702', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c0702000217000000000000', 'hex'))
-        await assert.equal(promise, {
+        assert.deepEqual(await promise, {
             version: '0.2.23',
             serial: 'PU2524L06700210'
         })
@@ -40,21 +33,21 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await assert.equal(promise).rejects.toThrow(/not connected/i)
+        await assert.rejects(promise, /not connected/i)
     })
     it('sets brightness', () => {
         const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
+        assert.deepEqual(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0409020a', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('cannot set button color', () => {
-        assert.equal(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Setting key color not available on this device/)
+        assert.throws(() => device.setButtonColor({ id: 'triangle', color: 'blue' }), /Setting key color not available on this device/)
     })
     it('cannot vibrate', () => {
-        assert.equal(() => device.vibrate()).toThrow(/Vibration not available on this device/)
+        assert.throws(() => device.vibrate(), /Vibration not available on this device/)
     })
     it('emits a `touchstart` and a `down` event when a key is pressed', () => {
         const touchListener = mock.fn()
@@ -62,8 +55,8 @@ describe('Commands', () => {
         device.on('touchstart', touchListener)
         device.on('down', downListener)
         device.onReceive(Buffer.from('0500002900', 'hex'))
-        assert.equal(downListener.calls[0].arguments[0], { id: 14 })
-        assert.equal(touchListener.calls[0].arguments[0], {
+        assert.deepEqual(downListener.mock.calls[0].arguments[0], { id: 14 })
+        assert.deepEqual(touchListener.mock.calls[0].arguments[0], {
             touches: [{ id: 0, x: 4.5 * 96, y: 2.5 * 96, target: { key: 14 } }],
             changedTouches: [{ id: 0, x: 4.5 * 96, y: 2.5 * 96, target: { key: 14 } }]
         })
@@ -83,12 +76,12 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(480 * 288)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -97,12 +90,12 @@ describe('Drawing (Callback API)', () => {
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(96 * 96)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels without refreshing the screen', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -126,12 +119,12 @@ describe('Drawing (Buffer API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(480 * 288)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
         const sender = mock.method(device.connection, 'send')
@@ -139,16 +132,16 @@ describe('Drawing (Buffer API)', () => {
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(96 * 96)
-        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
+        assertIsPixelBuffer(sender.mock.calls[0].arguments[0], { displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
         assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
+        assert.deepEqual(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await assert.equal(device.drawScreen('center', buffer)).rejects.toThrow(/expected buffer length of 276480, got 30/i)
+        await assert.rejects(device.drawScreen('center', buffer), /expected buffer length of 276480, got 30/i)
     })
 })

--- a/test/device-razer-x.test.js
+++ b/test/device-razer-x.test.js
@@ -112,6 +112,11 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
+    // TODO: Mock canvas lib
+    // it('informs the user if the canvas library is not installed', () => {
+    //     jest.mock('canvas', () => {})
+    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-razer-x.test.js
+++ b/test/device-razer-x.test.js
@@ -112,11 +112,6 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
-    // TODO: Mock canvas lib
-    // it('informs the user if the canvas library is not installed', () => {
-    //     jest.mock('canvas', () => {})
-    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
-    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-razer-x.test.js
+++ b/test/device-razer-x.test.js
@@ -25,14 +25,14 @@ describe('Commands', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('retrieves device information', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030301', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f03015055323532344c303637303032313020202020202020202020202020', 'hex'))
         await delay(20)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030702', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c0702000217000000000000', 'hex'))
-        await expect(promise).resolves.toEqual({
+        await assert.equal(promise, {
             version: '0.2.23',
             serial: 'PU2524L06700210'
         })
@@ -40,30 +40,30 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await expect(promise).rejects.toThrow(/not connected/i)
+        await assert.equal(promise).rejects.toThrow(/not connected/i)
     })
     it('sets brightness', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('04090100', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0409020a', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('cannot set button color', () => {
-        expect(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Setting key color not available on this device/)
+        assert.equal(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Setting key color not available on this device/)
     })
     it('cannot vibrate', () => {
-        expect(() => device.vibrate()).toThrow(/Vibration not available on this device/)
+        assert.equal(() => device.vibrate()).toThrow(/Vibration not available on this device/)
     })
     it('emits a `touchstart` and a `down` event when a key is pressed', () => {
-        const touchListener = jest.fn()
-        const downListener = jest.fn()
+        const touchListener = mock.fn()
+        const downListener = mock.fn()
         device.on('touchstart', touchListener)
         device.on('down', downListener)
         device.onReceive(Buffer.from('0500002900', 'hex'))
-        expect(downListener).toHaveBeenCalledWith({ id: 14 })
-        expect(touchListener).toHaveBeenCalledWith({
+        assert.equal(downListener.calls[0].arguments[0], { id: 14 })
+        assert.equal(touchListener.calls[0].arguments[0], {
             touches: [{ id: 0, x: 4.5 * 96, y: 2.5 * 96, target: { key: 14 } }],
             changedTouches: [{ id: 0, x: 4.5 * 96, y: 2.5 * 96, target: { key: 14 } }]
         })
@@ -75,7 +75,7 @@ describe('Drawing (Callback API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to main display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('center', (ctx, w, h) => {
             ctx.fillStyle = '#00f' // blue
             ctx.fillRect(0, 0, w, h)
@@ -83,34 +83,34 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(480 * 288)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawKey(6, (ctx, w, h) => {
             ctx.fillStyle = '#fff'
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(96 * 96)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels without refreshing the screen', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawCanvas({ id: 'center', width: 10, height: 10, autoRefresh: false }, () => {})
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenCalledTimes(1)
+        assert.equal(sender.mock.calls.length, 1)
     })
 })
 describe('Drawing (Buffer API)', () => {
@@ -119,36 +119,36 @@ describe('Drawing (Buffer API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(480 * 288).fill([0x1f, 0x00])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('center', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(480 * 288)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 480, height: 288 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(96 * 96 * 2).fill(0xff)
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(96 * 96)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 96, y: 96, width: 96, height: 96 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await expect(device.drawScreen('center', buffer)).rejects.toThrow(/expected buffer length of 276480, got 30/i)
+        await assert.equal(device.drawScreen('center', buffer)).rejects.toThrow(/expected buffer length of 276480, got 30/i)
     })
 })

--- a/test/device-razer.test.js
+++ b/test/device-razer.test.js
@@ -144,11 +144,6 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
-    // TODO: Mock canvas lib
-    // it('informs the user if the canvas library is not installed', () => {
-    //     jest.mock('canvas', () => {})
-    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
-    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-razer.test.js
+++ b/test/device-razer.test.js
@@ -144,6 +144,11 @@ describe('Drawing (Callback API)', () => {
         await delay(10)
         expect(sender).toHaveBeenCalledTimes(1)
     })
+    // TODO: Mock canvas lib
+    // it('informs the user if the canvas library is not installed', () => {
+    //     jest.mock('canvas', () => {})
+    //     expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+    // })
 })
 describe('Drawing (Buffer API)', () => {
     beforeEach(() => {

--- a/test/device-razer.test.js
+++ b/test/device-razer.test.js
@@ -25,14 +25,14 @@ describe('Commands', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('retrieves device information', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const promise = device.getInfo()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030301', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030301', 'hex'))
         device.onReceive(Buffer.from('1f0301525a32313031303133303030333936373030313338413030303120', 'hex'))
         await delay(20)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('030702', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('030702', 'hex'))
         device.onReceive(Buffer.from('0c0702000208050000000000', 'hex'))
-        await expect(promise).resolves.toEqual({
+        await assert.equal(promise, {
             version: '0.2.8',
             serial: 'RZ2101013000396700138A0001'
         })
@@ -40,33 +40,33 @@ describe('Commands', () => {
     it('rejects retrieving device information if not connected', async() => {
         device.connection = { send: () => {}, isReady: () => false }
         const promise = device.getInfo()
-        await expect(promise).rejects.toThrow(/not connected/i)
+        await assert.equal(promise).rejects.toThrow(/not connected/i)
     })
     it('sets brightness', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setBrightness(0)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('04090100', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('04090100', 'hex'))
         device.setBrightness(1)
         // 0x0b should be max brightness
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0409020a', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0409020a', 'hex'))
     })
     it('sets button color', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.setButtonColor({ id: 4, color: 'red' })
-        expect(sender).toHaveBeenCalledWith(Buffer.from('0702010bff0000', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('0702010bff0000', 'hex'))
     })
     it('errors on unknown button passed', () => {
-        expect(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
+        assert.equal(() => device.setButtonColor({ id: 'triangle', color: 'blue' })).toThrow(/Invalid button/)
     })
     it('vibrates short by default', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate()
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0101', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0101', 'hex'))
     })
     it('vibrates a specific pattern', () => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.vibrate(0x56)
-        expect(sender).toHaveBeenCalledWith(Buffer.from('041b0156', 'hex'))
+        assert.equal(sender.mock.calls[0].arguments[0], Buffer.from('041b0156', 'hex'))
     })
 })
 describe('Drawing (Callback API)', () => {
@@ -75,7 +75,7 @@ describe('Drawing (Callback API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to left display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('left', (ctx, w, h) => {
             ctx.fillStyle = '#f00' // red
             ctx.fillRect(0, 0, w, h)
@@ -83,15 +83,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so first 5 bits for full red is 0xf800, or 0x00f8 in LE
         const pixels = '00f8'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to right display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('right', (ctx, w, h) => {
             ctx.fillStyle = '#0f0' // green
             ctx.fillRect(0, 0, w, h)
@@ -99,15 +99,15 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const pixels = 'e007'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawScreen('center', (ctx, w, h) => {
             ctx.fillStyle = '#00f' // blue
             ctx.fillRect(0, 0, w, h)
@@ -115,34 +115,34 @@ describe('Drawing (Callback API)', () => {
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const pixels = '1f00'.repeat(360 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawKey(6, (ctx, w, h) => {
             ctx.fillStyle = '#fff'
             ctx.fillRect(0, 0, w, h)
         })
         const pixels = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(pixels)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), pixels)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels without refreshing the screen', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         device.drawCanvas({ id: 'center', width: 10, height: 10, autoRefresh: false }, () => {})
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenCalledTimes(1)
+        assert.equal(sender.mock.calls.length, 1)
     })
 })
 describe('Drawing (Buffer API)', () => {
@@ -151,64 +151,64 @@ describe('Drawing (Buffer API)', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('writes pixels to left display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(60 * 270).fill([0x00, 0xf8])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('left', buffer)
         const hex = '00f8'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 0, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to right display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(60 * 270).fill([0xe0, 0x07])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('right', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so middle 6 bits for full green is 0x07e0, or 0xe007 in LE
         const hex = 'e007'.repeat(60 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 420, y: 0, width: 60, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to center display', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(360 * 270).fill([0x1f, 0x00])
         const buffer = Buffer.from(pixels.flat())
         device.drawScreen('center', buffer)
         // Color format is 5-6-5 16-bit RGB
         // so last 5 bits for full blue is 0x001f, or 0x1f00 in LE
         const hex = '1f00'.repeat(360 * 270)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 60, y: 0, width: 360, height: 270 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('writes pixels to a specific key area', async() => {
-        const sender = jest.spyOn(device.connection, 'send')
+        const sender = mock.method(device.connection, 'send')
         const pixels = Array(90 * 90 * 2).fill(0xff)
         const buffer = Buffer.from(pixels)
         device.drawKey(6, buffer)
         const hex = 'ffff'.repeat(90 * 90)
-        expect(sender.mock.calls[0][0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
-        expect(sender.mock.calls[0][0].slice(13).toString('hex')).toEqual(hex)
+        assert.equal(sender.mock.calls[0].arguments[0]).toBePixelBuffer({ displayID: 0x004d, x: 180 + 60, y: 90, width: 90, height: 90 })
+        assert.equal(sender.mock.calls[0].arguments[0].slice(13).toString('hex'), hex)
         // Confirm write
         device.onReceive(Buffer.from('041001', 'hex'))
         await delay(10)
-        expect(sender).toHaveBeenNthCalledWith(2, Buffer.from('050f02004d', 'hex'))
+        assert.equal(sender.mock.calls[1].arguments[0], Buffer.from('050f02004d', 'hex'))
     })
     it('reports an error if the buffer is the wrong size', async() => {
         const pixels = Array(30).fill(0xff)
         const buffer = Buffer.from(pixels)
-        await expect(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
+        await assert.equal(device.drawScreen('left', buffer)).rejects.toThrow(/expected buffer length of 32400, got 30/i)
     })
 })

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -1,5 +1,7 @@
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
+
 import { discover, LoupedeckLive, LoupedeckLiveS } from '../index.js'
-import { jest } from '@jest/globals'
 import { SerialPort } from 'serialport'
 
 describe('Device Discovery', () => {
@@ -14,7 +16,7 @@ describe('Device Discovery', () => {
                 productId: '52b5'
             }
         ])
-        await assert.equal(discover()).rejects.toThrow(/no devices found/i)
+        assert.rejects(discover(), /no devices found/i)
         spy.mock.restore()
     })
     it('can auto-discover a Loupedeck Live device', async() => {
@@ -29,7 +31,7 @@ describe('Device Discovery', () => {
             }
         ])
         const device = await discover({ autoConnect: false })
-        assert.equal(device).toBeInstanceOf(LoupedeckLive)
+        assert(device instanceof LoupedeckLive)
         spy.mock.restore()
     })
     it('can auto-discover a Loupedeck Live S device', async() => {
@@ -44,7 +46,7 @@ describe('Device Discovery', () => {
             }
         ])
         const device = await discover({ autoConnect: false })
-        assert.equal(device).toBeInstanceOf(LoupedeckLiveS)
+        assert(device instanceof LoupedeckLiveS)
         spy.mock.restore()
     })
     it('errors on unknown devices', async() => {
@@ -58,7 +60,7 @@ describe('Device Discovery', () => {
                 productId: '000d'
             }
         ])
-        await assert.equal(discover()).rejects.toThrow(/not yet supported/i)
+        await assert.rejects(discover(), /not yet supported/i)
         spy.mock.restore()
     })
 })

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -4,7 +4,7 @@ import { SerialPort } from 'serialport'
 
 describe('Device Discovery', () => {
     it('reports if no devices found', async() => {
-        const spy = jest.spyOn(SerialPort, 'list').mockImplementation(() => [
+        const spy = mock.method(SerialPort, 'list', () => [
             {
                 path: '/dev/cu.usbmodem-222',
                 manufacturer: 'Apple',
@@ -14,11 +14,11 @@ describe('Device Discovery', () => {
                 productId: '52b5'
             }
         ])
-        await expect(discover()).rejects.toThrow(/no devices found/i)
-        spy.mockRestore()
+        await assert.equal(discover()).rejects.toThrow(/no devices found/i)
+        spy.mock.restore()
     })
     it('can auto-discover a Loupedeck Live device', async() => {
-        const spy = jest.spyOn(SerialPort, 'list').mockImplementation(() => [
+        const spy = mock.method(SerialPort, 'list', () => [
             {
                 path: '/dev/cu.usbmodem-333',
                 manufacturer: 'Loupedeck',
@@ -29,11 +29,11 @@ describe('Device Discovery', () => {
             }
         ])
         const device = await discover({ autoConnect: false })
-        expect(device).toBeInstanceOf(LoupedeckLive)
-        spy.mockRestore()
+        assert.equal(device).toBeInstanceOf(LoupedeckLive)
+        spy.mock.restore()
     })
     it('can auto-discover a Loupedeck Live S device', async() => {
-        const spy = jest.spyOn(SerialPort, 'list').mockImplementation(() => [
+        const spy = mock.method(SerialPort, 'list', () => [
             {
                 path: '/dev/cu.usbmodem-444',
                 manufacturer: 'Loupedeck',
@@ -44,11 +44,11 @@ describe('Device Discovery', () => {
             }
         ])
         const device = await discover({ autoConnect: false })
-        expect(device).toBeInstanceOf(LoupedeckLiveS)
-        spy.mockRestore()
+        assert.equal(device).toBeInstanceOf(LoupedeckLiveS)
+        spy.mock.restore()
     })
     it('errors on unknown devices', async() => {
-        const spy = jest.spyOn(SerialPort, 'list').mockImplementation(() => [
+        const spy = mock.method(SerialPort, 'list', () => [
             {
                 path: '/dev/cu.usbmodem-444',
                 manufacturer: 'Loupedeck',
@@ -58,7 +58,7 @@ describe('Device Discovery', () => {
                 productId: '000d'
             }
         ])
-        await expect(discover()).rejects.toThrow(/not yet supported/i)
-        spy.mockRestore()
+        await assert.equal(discover()).rejects.toThrow(/not yet supported/i)
+        spy.mock.restore()
     })
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+
+export function assertIsPixelBuffer(received, { displayID, x, y, width, height }) {
+    assert(received.readUInt16BE(0) === 0xff10, `Header should be 0xff10, found 0x${received.readUInt16BE().toString(16)}`)
+    assert(received.readUInt16BE(3) === displayID, `Display ID should be ${displayID}, but found 0x${received.readUInt16BE(3).toString(16)}`)
+    assert(received.readUInt16BE(5) === x, `X coordinate should be ${x}, but found ${received.readUInt16BE(3)}`)
+    assert(received.readUInt16BE(7) === y, `Y coordinate should be ${y}, but found ${received.readUInt16BE(5)}`)
+    assert(received.readUInt16BE(9) === width, `Width should be ${width}, but found ${received.readUInt16BE(9)}`)
+    assert(received.readUInt16BE(11) === height, `Height should be ${height}, but found ${received.readUInt16BE(11)}`)
+    const correctLength = 13 + width * height * 2
+    assert(received.length === correctLength, `Buffer length should be ${correctLength}, but found ${received.length}`)
+}
+
+export const delay = ms => new Promise(res => setTimeout(res, ms))

--- a/test/optional-deps.test.js
+++ b/test/optional-deps.test.js
@@ -1,5 +1,6 @@
-import { jest } from '@jest/globals'
-jest.unstable_mockModule('canvas', () => ({}))
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it, mock } from 'node:test'
+mock.module('canvas', {})
 const { LoupedeckLiveS } = await import('../index.js')
 
 let device
@@ -9,6 +10,6 @@ describe('Optional Dependencies', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('informs the user if the canvas library is not installed', () => {
-        assert.equal(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+        assert.throws(() => device.drawKey(6, () => {}), /using callbacks requires the `canvas` library/i)
     })
 })

--- a/test/optional-deps.test.js
+++ b/test/optional-deps.test.js
@@ -9,6 +9,6 @@ describe('Optional Dependencies', () => {
         device.connection = { send: () => {}, isReady: () => true }
     })
     it('informs the user if the canvas library is not installed', () => {
-        expect(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
+        assert.equal(() => device.drawKey(6, () => {})).toThrow(/using callbacks requires the `canvas` library/i)
     })
 })

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,35 +1,37 @@
-import { MagicByteLengthParser } from '../parser'
-import { jest } from '@jest/globals'
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
+
+import { MagicByteLengthParser } from '../parser.js'
 
 describe('MagicByteLengthParser', () => {
     it('transforms data by magic byte', () => {
         const parser = new MagicByteLengthParser({ magicByte: 0x32 })
-        const fn = jest.fn()
+        const fn = mock.fn()
         parser.on('data', fn)
         parser.write(Buffer.from([0x32, 0x01, 0x88, 0x32]))
         parser.write(Buffer.from([0x03, 0xff, 0x32, 0xff, 0x32, 0x02, 0xaa]))
         parser.write(Buffer.from([0xab]))
-        expect(fn).toHaveBeenCalledTimes(3)
-        expect(fn.mock.calls[0][0]).toEqual(Buffer.from([0x88]))
-        expect(fn.mock.calls[1][0]).toEqual(Buffer.from([0xff, 0x32, 0xff]))
-        expect(fn.mock.calls[2][0]).toEqual(Buffer.from([0xaa, 0xab]))
+        assert.equal(fn.mock.calls.length, 3)
+        assert.deepEqual(fn.mock.calls[0].arguments[0], Buffer.from([0x88]))
+        assert.deepEqual(fn.mock.calls[1].arguments[0], Buffer.from([0xff, 0x32, 0xff]))
+        assert.deepEqual(fn.mock.calls[2].arguments[0], Buffer.from([0xaa, 0xab]))
     })
     it('handles zero length indicators', () => {
         const parser = new MagicByteLengthParser({ magicByte: 0x11 })
-        const fn = jest.fn()
+        const fn = mock.fn()
         parser.on('data', fn)
         parser.write(Buffer.from([0x11, 0x00, 0x11, 0x11]))
         parser.write(Buffer.alloc(0x11).fill(0xff))
-        expect(fn).toHaveBeenCalledTimes(1)
-        expect(fn.mock.calls[0][0]).toEqual(Buffer.alloc(0x11).fill(0xff))
+        assert.equal(fn.mock.calls.length, 1)
+        assert.deepEqual(fn.mock.calls[0].arguments[0], Buffer.alloc(0x11).fill(0xff))
     })
     it('flushes on end', () => {
         const parser = new MagicByteLengthParser({ magicByte: 0xff })
-        const fn = jest.fn()
+        const fn = mock.fn()
         parser.on('data', fn)
         parser.write(Buffer.from([0xff, 0x03, 0x00]))
-        expect(fn).not.toHaveBeenCalled()
+        assert.equal(fn.mock.calls.length, 0)
         parser.end()
-        expect(fn).toHaveBeenCalledWith(Buffer.from([0xff, 0x03, 0x00]))
+        assert.deepEqual(fn.mock.calls[0].arguments[0], Buffer.from([0xff, 0x03, 0x00]))
     })
 })


### PR DESCRIPTION
 * refactor!: Migrates the library to ESM
 * test: Removes Jest and migrates all tests to use the native Node test runnure